### PR TITLE
Correct two missing underscore references

### DIFF
--- a/parser/Context.ts
+++ b/parser/Context.ts
@@ -3,6 +3,7 @@ import { IMetaData } from "./interface/IMetaData";
 import { IToken } from "./interface/IToken";
 import { IMessage } from "./interface/IMessage";
 import { IParseInstruction } from "./interface/IParseInstruction";
+import * as _ from "underscore";
 
 export class Context implements IContext {
 

--- a/parser/TokenStream.ts
+++ b/parser/TokenStream.ts
@@ -1,7 +1,7 @@
 ﻿import { IToken, TokenCategory } from "./interface/IToken";
 import { IMessage, MessageType } from "./interface/IMessage";
 import { ITokenStream } from "./interface/ITokenStream";
-
+import * as _ from "underscore";
 import { TokenHelper } from "./TokenHelper";
 
 export class TokenStream implements ITokenStream {


### PR DESCRIPTION
Added missing underscore references.

Oddly, from this version (pulled direct from master) `npm test` returns:

```
c:\Github\gareththegeek\corewar>npm test

> corewar@1.0.0 test c:\Github\gareththegeek\corewar
> nyc jasmine-ts

Started
.............................................................................................................................................................................................................................................................................................................


301 specs, 0 failures
Finished in 0.531 seconds
```