### PR TITLE
Add standard to options

### DIFF
--- a/canvas-ui/CoreRenderer.ts
+++ b/canvas-ui/CoreRenderer.ts
@@ -1,6 +1,6 @@
-﻿import { IInstructionSerialiser } from "./interface/IInstructionSerialiser";
-import { IPoint } from "./interface/IPoint";
-import { ICore, ICoreAccessEventArgs, CoreAccessType } from "../../simulator/interface/ICore";
+﻿import { IInstructionSerialiser } from "./IInstructionSerialiser";
+import { IPoint } from "./IPoint";
+import { ICore, ICoreAccessEventArgs, CoreAccessType } from "../simulator/interface/ICore";
 import * as _ from "underscore";
 
 export class CoreRenderer {

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,12 +2,16 @@ import { IParser } from "./parser/interface/IParser";
 import { IParseOptions } from "./parser/interface/IParseOptions";
 import { IParseResult } from "./parser/interface/IParseResult";
 import { IToken } from "./parser/interface/IToken";
+import { IOptions } from "./simulator/interface/IOptions";
+import { IState } from "./simulator/interface/IState";
 
 declare namespace corewar {
 
   export interface Api {
 
     new();
+
+    initialiseSimulator(opts: IOptions, parseResults: IParseResult[], messageProvider: any) : IState;
 
     parse(document: string, options?: IParseOptions): IParseResult;
 

--- a/index.ts
+++ b/index.ts
@@ -102,6 +102,7 @@ class Api {
 
         var options = _.defaults({
             coresize: opts.coresize,
+            minSeparation: opts.minSeparation,
             instructionLimit: opts.instructionLimit,
             standard: opts.standard
         }, Defaults);

--- a/index.ts
+++ b/index.ts
@@ -39,6 +39,7 @@ import { Fetcher } from "./simulator/Fetcher";
 import { Simulator } from "./simulator/Simulator";
 import { EndCondition } from "./simulator/EndCondition";
 import { OptionValidator } from "./simulator/OptionValidator";
+import { IOptions } from "./simulator/interface/IOptions";
 
 import { ILoader } from "./simulator/interface/ILoader";
 
@@ -97,11 +98,12 @@ class Api {
             new OptionValidator());
     }
 
-    public initialiseSimulator(standardId: number, parseResults: IParseResult[], messageProvider: any) : IState {
+    public initialiseSimulator(opts: IOptions, parseResults: IParseResult[], messageProvider: any) : IState {
 
         var options = _.defaults({
-            coresize: 64,
-            standard: standardId
+            coresize: opts.coresize,
+            instructionLimit: opts.instructionLimit,
+            standard: opts.standard
         }, Defaults);
 
         this.core.initialise(options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "HTML5 & javascript implementation of the classic game [corewar](https://en.wikipedia.org/wiki/Core_War)",
   "main": "./dist/index.js",
   "scripts": {

--- a/parser/integration/references.ts
+++ b/parser/integration/references.ts
@@ -1,3 +1,0 @@
-﻿/// <reference path="../../corewar/references.ts" />
-/// <reference path="tests/itestwarrior.ts" />
-/// <reference path="tests/testloader.ts" />

--- a/simulator/interface/IOptions.ts
+++ b/simulator/interface/IOptions.ts
@@ -8,7 +8,7 @@ export interface IOptions {
     instructionLimit?: number;
     maxTasks?: number;
     minSeparation?: number;
-    standard: number;
+    standard?: number;
     // TODO readDistance?: number;
     // TODO separation?: number;
     // TODO writeDistance?: number;

--- a/simulator/interface/IOptions.ts
+++ b/simulator/interface/IOptions.ts
@@ -8,6 +8,7 @@ export interface IOptions {
     instructionLimit?: number;
     maxTasks?: number;
     minSeparation?: number;
+    standard: number;
     // TODO readDistance?: number;
     // TODO separation?: number;
     // TODO writeDistance?: number;


### PR DESCRIPTION
Add the `standard` to the options so the UI can more easily pass a single options object containing what is needed to start up the simulator.

Fixed a webpack build issue with the UI files I'd moved in #76 

Removed a rogue references.ts which had ninja'd its way back in