### PR TITLE
Publish core access events from run

### DIFF
--- a/simulator/Core.ts
+++ b/simulator/Core.ts
@@ -53,7 +53,7 @@ export class Core implements ICore {
 
         this.publisher.publish({
             type: MessageType.CoreAccess,
-            payload: accessEventArgs
+            payload: [ accessEventArgs ]
         });
     }
 

--- a/simulator/Core.ts
+++ b/simulator/Core.ts
@@ -119,4 +119,12 @@ export class Core implements ICore {
 
         return instruction;
     }
+
+    public publishCoreAccesses(): void {
+
+        this.publisher.publish({
+            type: MessageType.CoreAccess,
+            payload: this.locations.map(location => location.access)
+        });
+    }
 }

--- a/simulator/Simulator.ts
+++ b/simulator/Simulator.ts
@@ -97,6 +97,8 @@ export class Simulator implements ISimulator {
         finally {
             this.publisher.setAllMessagesEnabled(true);
         }
+
+        this.core.publishCoreAccesses();
     }
 
     public step(): boolean {

--- a/simulator/Simulator.ts
+++ b/simulator/Simulator.ts
@@ -85,6 +85,11 @@ export class Simulator implements ISimulator {
         this.publishInitialise(this.state);
     }
 
+    private publishCoreAccesses() {
+
+        
+    }
+
     public run(): void {
 
         try {
@@ -97,6 +102,8 @@ export class Simulator implements ISimulator {
         finally {
             this.publisher.setAllMessagesEnabled(true);
         }
+
+        this.publishCoreAccesses();
     }
 
     public step(): boolean {

--- a/simulator/Simulator.ts
+++ b/simulator/Simulator.ts
@@ -85,11 +85,6 @@ export class Simulator implements ISimulator {
         this.publishInitialise(this.state);
     }
 
-    private publishCoreAccesses() {
-
-        
-    }
-
     public run(): void {
 
         try {
@@ -102,8 +97,6 @@ export class Simulator implements ISimulator {
         finally {
             this.publisher.setAllMessagesEnabled(true);
         }
-
-        this.publishCoreAccesses();
     }
 
     public step(): boolean {

--- a/simulator/interface/ICore.ts
+++ b/simulator/interface/ICore.ts
@@ -25,4 +25,5 @@ export interface ICore {
     getAt(address: number): IInstruction;
     getWithInfoAt(address: number): ICoreLocation;
     setAt(task: ITask, address: number, instruction: IInstruction): void;
+    publishCoreAccesses(): void;
 }

--- a/simulator/tests/CoreTests.ts
+++ b/simulator/tests/CoreTests.ts
@@ -204,11 +204,11 @@ describe("Core", () => {
 
         expect(publisher.publish).to.have.been.calledWith({
             type: MessageType.CoreAccess,
-            payload: {
+            payload: [{
                 warriorId: task.warrior.id,
                 accessType: CoreAccessType.read,
                 address: 2
-            }
+            }]
         });
     });
 
@@ -223,11 +223,11 @@ describe("Core", () => {
 
         expect(publisher.publish).to.have.been.calledWith({
             type: MessageType.CoreAccess,
-            payload: {
+            payload: [{
                 warriorId: task.warrior.id,
                 accessType: CoreAccessType.write,
                 address: 2
-            }
+            }]
         });
     });
 
@@ -242,11 +242,11 @@ describe("Core", () => {
 
         expect(publisher.publish).to.have.been.calledWith({
             type: MessageType.CoreAccess,
-            payload: {
+            payload: [{
                 warriorId: task.warrior.id,
                 accessType: CoreAccessType.execute,
                 address: 2
-            }
+            }]
         });
     });
 
@@ -281,7 +281,7 @@ describe("Core", () => {
 
         const task = buildTask(7);
 
-        const expected =  {
+        const expected = {
 
             warriorId: task.warrior.id,
             accessType: CoreAccessType.write,
@@ -293,5 +293,46 @@ describe("Core", () => {
         const actual = core.getWithInfoAt(2);
 
         expect(actual.access).to.be.deep.equal(expected);
+    });
+
+    it("Publishes core access event for all core locations", () => {
+
+        var core = new Core(publisher);
+        core.initialise(Object.assign({}, Defaults, { coresize: 4 }));
+
+        const task1 = buildTask(7);
+        const task2 = buildTask(5);
+
+        const expected = [{
+            warriorId: task1.warrior.id,
+            accessType: CoreAccessType.write,
+            address: 0
+        }, {
+            accessType: CoreAccessType.write,
+            address: 1
+        }, {
+            warriorId: task2.warrior.id,
+            accessType: CoreAccessType.read,
+            address: 2
+        }, {
+            warriorId: task1.warrior.id,
+            accessType: CoreAccessType.execute,
+            address: 3
+        }];
+
+        core.setAt(task1, 0, buildInstruction());
+        core.readAt(task2, 2);
+        core.executeAt(task1, 3);
+
+        publisher.publish = sinon.stub();
+
+        core.publishCoreAccesses();
+
+        expect(publisher.publish).to.have.callCount(1);
+
+        expect(publisher.publish).to.have.been.calledWith({
+            type: MessageType.CoreAccess,
+            payload: expected
+        });
     });
 });

--- a/simulator/tests/DecoderTests.ts
+++ b/simulator/tests/DecoderTests.ts
@@ -52,7 +52,8 @@ describe("Decoder",() => {
             },
             initialise: (options: IOptions) => {
                 //
-            }
+            },
+            publishCoreAccesses: sinon.stub()
         };
     });
 

--- a/simulator/tests/ExecutiveTests.ts
+++ b/simulator/tests/ExecutiveTests.ts
@@ -67,7 +67,8 @@ describe("Executive", () => {
             wrap: wrapSpy,
             initialise: (options: IOptions) => {
                 //
-            }
+            },
+            publishCoreAccesses: sinon.stub()
         };
 
         state = {

--- a/simulator/tests/FetcherTests.ts
+++ b/simulator/tests/FetcherTests.ts
@@ -38,7 +38,8 @@ describe("Fetcher",() => {
             },
             initialise: (options: IOptions) => {
                 //
-            }
+            },
+            publishCoreAccesses: sinon.stub()
         };
 
         state = {

--- a/simulator/tests/LoaderTests.ts
+++ b/simulator/tests/LoaderTests.ts
@@ -49,7 +49,8 @@ describe("Loader",() => {
             getWithInfoAt: sinon.stub(),
             setAt: sinon.stub(),
             initialise: sinon.stub(),
-            wrap: sinon.stub()
+            wrap: sinon.stub(),
+            publishCoreAccesses: sinon.stub()
         };
     });
 

--- a/simulator/tests/SimulatorTests.ts
+++ b/simulator/tests/SimulatorTests.ts
@@ -404,4 +404,11 @@ describe("Simulator", () => {
 
         expect(publisher.setAllMessagesEnabled).to.have.been.calledWith(true);
     });
+
+    it("Should publish core access event for all core addresses after run", () => {
+
+        simulator.run();
+
+        expect(core.publishCoreAccesses).to.have.been.called;
+    });
 });

--- a/simulator/tests/SimulatorTests.ts
+++ b/simulator/tests/SimulatorTests.ts
@@ -50,7 +50,8 @@ describe("Simulator", () => {
             getWithInfoAt: sinon.stub(),
             setAt: sinon.stub(),
             wrap: sinon.stub(),
-            initialise: sinon.stub()
+            initialise: sinon.stub(),
+            publishCoreAccesses: sinon.stub()
         };
 
         loader = {

--- a/simulator/tests/WarriorLoaderTests.ts
+++ b/simulator/tests/WarriorLoaderTests.ts
@@ -61,7 +61,8 @@ describe("WarriorLoader", () => {
             getWithInfoAt: sinon.stub(),
             setAt: sinon.stub().callsFake((task: ITask, index: number, instruction: IInstruction) => {
                 core.instructions[index] = instruction;
-            })
+            }),
+            publishCoreAccesses: sinon.stub()
         };
         for (var i = 0; i < size; i++) {
             core.instructions.push({


### PR DESCRIPTION
**Contains Breaking Change** - CORE_ACCESS message payload is now an array of `CoreAccessEventArg` rather than a single instance.

Run will publish a CORE_ACCESS message containing most recent access event arg for each core location following run - #112 