### PR TITLE
Fix non endgame warrior death

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.56",
+  "version": "0.0.58",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "HTML5 & javascript implementation of the classic game [corewar](https://en.wikipedia.org/wiki/Core_War)",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "description": "HTML5 & javascript implementation of the classic game [corewar](https://en.wikipedia.org/wiki/Core_War)",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "description": "HTML5 & javascript implementation of the classic game [corewar](https://en.wikipedia.org/wiki/Core_War)",
   "main": "./dist/index.js",
   "scripts": {

--- a/simulator/Fetcher.ts
+++ b/simulator/Fetcher.ts
@@ -7,28 +7,42 @@ export class Fetcher implements IFetcher {
 
     public fetch(state: IState, core: ICore): IExecutionContext {
 
-        var wi = state.warriorIndex;
-        var warrior = state.warriors[wi];
+        try {
+            var wi = state.warriorIndex;
+            var warrior = state.warriors[wi];
 
-        var ti = warrior.taskIndex;
-        var task = warrior.tasks[ti];
+            // skip dead warriors
+            if(warrior.tasks.length === 0) {
+                wi = (wi + 1) % state.warriors.length;
+                warrior = state.warriors[wi]
+            }
 
-        state.warriorIndex = (wi + 1) % state.warriors.length;
-        warrior.taskIndex = (ti + 1) % warrior.tasks.length;
+            var ti = warrior.taskIndex;
+            var task = warrior.tasks[ti];
 
-        var ip = task.instructionPointer;
-        var instruction = core.executeAt(task, ip);
+            state.warriorIndex = (wi + 1) % state.warriors.length;
+            warrior.taskIndex = (ti + 1) % warrior.tasks.length;
 
-        task.instructionPointer = (ip + 1) % state.options.coresize;
-        // TODO should we instantiate an object everytime?
-        return {
-            core: core,
-            instructionPointer: ip,
-            instruction: instruction,
-            taskIndex: ti,
-            task: task,
-            warriorIndex: wi,
-            warrior: warrior
-        };
+
+            var ip = task.instructionPointer;
+            var instruction = core.executeAt(task, ip);
+            task.instructionPointer = (ip + 1) % state.options.coresize;
+
+            // TODO should we instantiate an object everytime?
+            return {
+                core: core,
+                instructionPointer: ip,
+                instruction: instruction,
+                taskIndex: ti,
+                task: task,
+                warriorIndex: wi,
+                warrior: warrior
+            };
+
+        } catch (error) {
+            debugger
+        }
+
+
     }
 }

--- a/simulator/Fetcher.ts
+++ b/simulator/Fetcher.ts
@@ -7,42 +7,35 @@ export class Fetcher implements IFetcher {
 
     public fetch(state: IState, core: ICore): IExecutionContext {
 
-        try {
-            var wi = state.warriorIndex;
-            var warrior = state.warriors[wi];
+        var wi = state.warriorIndex;
+        var warrior = state.warriors[wi];
 
-            // skip dead warriors
-            if(warrior.tasks.length === 0) {
-                wi = (wi + 1) % state.warriors.length;
-                warrior = state.warriors[wi]
-            }
-
-            var ti = warrior.taskIndex;
-            var task = warrior.tasks[ti];
-
-            state.warriorIndex = (wi + 1) % state.warriors.length;
-            warrior.taskIndex = (ti + 1) % warrior.tasks.length;
-
-
-            var ip = task.instructionPointer;
-            var instruction = core.executeAt(task, ip);
-            task.instructionPointer = (ip + 1) % state.options.coresize;
-
-            // TODO should we instantiate an object everytime?
-            return {
-                core: core,
-                instructionPointer: ip,
-                instruction: instruction,
-                taskIndex: ti,
-                task: task,
-                warriorIndex: wi,
-                warrior: warrior
-            };
-
-        } catch (error) {
-            debugger
+        // skip dead warriors
+        if(warrior.tasks.length === 0) {
+            wi = (wi + 1) % state.warriors.length
+            warrior = state.warriors[wi]
         }
 
+        var ti = warrior.taskIndex;
+        var task = warrior.tasks[ti];
 
+        state.warriorIndex = (wi + 1) % state.warriors.length;
+        warrior.taskIndex = (ti + 1) % warrior.tasks.length;
+
+
+        var ip = task.instructionPointer;
+        var instruction = core.executeAt(task, ip);
+        task.instructionPointer = (ip + 1) % state.options.coresize;
+
+        // TODO should we instantiate an object everytime?
+        return {
+            core: core,
+            instructionPointer: ip,
+            instruction: instruction,
+            taskIndex: ti,
+            task: task,
+            warriorIndex: wi,
+            warrior: warrior
+        };
     }
 }

--- a/simulator/Fetcher.ts
+++ b/simulator/Fetcher.ts
@@ -2,6 +2,7 @@
 import { IState } from "./interface/IState";
 import { ICore } from "./interface/ICore";
 import { IExecutionContext } from "./interface/IExecutionContext";
+import { IWarrior } from "./interface/IWarrior";
 
 export class Fetcher implements IFetcher {
 
@@ -10,8 +11,7 @@ export class Fetcher implements IFetcher {
         var wi = state.warriorIndex;
         var warrior = state.warriors[wi];
 
-        // skip dead warriors
-        if(warrior.tasks.length === 0) {
+        while(this.isDead(warrior)) {
             wi = (wi + 1) % state.warriors.length
             warrior = state.warriors[wi]
         }
@@ -37,5 +37,9 @@ export class Fetcher implements IFetcher {
             warriorIndex: wi,
             warrior: warrior
         };
+    }
+
+    private isDead(warrior: IWarrior) : boolean {
+        return warrior.tasks.length === 0
     }
 }


### PR DESCRIPTION
Fixes #124 where cores with > 2 warriors crap out when a dead warrior is `fetch`ed.

It's a pretty basic fix, let me know if you can see a more elegant way to fix it