### PR TITLE
Bug 130 fetcher sees dead tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "HTML5 & javascript implementation of the classic game [corewar](https://en.wikipedia.org/wiki/Core_War)",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "description": "HTML5 & javascript implementation of the classic game [corewar](https://en.wikipedia.org/wiki/Core_War)",
   "main": "./dist/index.js",
   "scripts": {

--- a/simulator/Executive.ts
+++ b/simulator/Executive.ts
@@ -173,8 +173,10 @@ export class Executive implements IExecutive {
     private dat(context: IExecutionContext) {
         //Remove current task from the queue
         var ti = context.taskIndex;
-        context.warrior.taskIndex = context.taskIndex;
         context.warrior.tasks.splice(ti, 1);
+        // wrap the warrior task index to cater for the event when
+        // we just chomped off the last task
+        context.warrior.taskIndex = ti % context.warrior.tasks.length;
 
         this.publishTaskCount(context.warrior.id, context.warrior.tasks.length);
     }


### PR DESCRIPTION
Resolve issue where the executive doesn't handle the removal of the final task in a warrior, resulting in array index out of bounds issues.

 Fixes #130