### PR TITLE
Add unit test for new executive wrapping logic

### DIFF
--- a/simulator/Fetcher.ts
+++ b/simulator/Fetcher.ts
@@ -22,7 +22,6 @@ export class Fetcher implements IFetcher {
         state.warriorIndex = (wi + 1) % state.warriors.length;
         warrior.taskIndex = (ti + 1) % warrior.tasks.length;
 
-
         var ip = task.instructionPointer;
         var instruction = core.executeAt(task, ip);
         task.instructionPointer = (ip + 1) % state.options.coresize;

--- a/simulator/tests/ExecutiveTests.ts
+++ b/simulator/tests/ExecutiveTests.ts
@@ -235,15 +235,16 @@ describe("Executive", () => {
         ]);
 
         const numberOfTasks = 3;
+        const expectedNumberOfTasks = numberOfTasks - 1;
 
-        var context = buildContext(3, 0, 0, 2, 3);
+        var context = buildContext(3, 0, 0, 2, numberOfTasks);
 
         var exec = new Executive(publisher);
         exec.initialise(options);
         exec.commandTable[OpcodeType.DAT].apply(exec, [context]);
 
         expect(state.warriors[0].taskIndex).to.be.equal(0);
-        expect(state.warriors[0].tasks.length).to.be.equal(numberOfTasks - 1);
+        expect(state.warriors[0].tasks.length).to.be.equal(expectedNumberOfTasks);
         expect(state.warriors[0].tasks[0].instructionPointer).to.be.equal(0);
         expect(state.warriors[0].tasks[1].instructionPointer).to.be.equal(0);
 
@@ -251,7 +252,7 @@ describe("Executive", () => {
             type: MessageType.TaskCount,
             payload: {
                 warriorId: 7,
-                taskCount: 2
+                taskCount: expectedNumberOfTasks
             }
         });
     });


### PR DESCRIPTION
Adds a unit test to ensure that when the final task is executed within a warrior, the warrior task index comes back as zero and the task is removed.

Tweaks the `buildContext` function to be more dynamic and allow current task index and number of tasks to be passed as params (with defaults that matched the existing tests)