### PR TITLE
Expose methods from default export directly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import { IParseResult } from "./parser/interface/IParseResult";
 import { IToken } from "./parser/interface/IToken";
 import { IOptions } from "./simulator/interface/IOptions";
 import { IState } from "./simulator/interface/IState";
+import { ICoreLocation } from "./simulator/interface/ICoreLocation";
 
 declare namespace corewar {
 
@@ -18,6 +19,10 @@ declare namespace corewar {
     serialise(tokens: IToken[]) : string;
 
     run() : void;
+
+    parse(redcode: string): IParseResult;
+
+    getWithInfoAt(address: number) : ICoreLocation;
 
   }
 

--- a/index.ts
+++ b/index.ts
@@ -1,70 +1,70 @@
-﻿import { IParser } from "./parser/interface/IParser";
-import { IToken } from "./parser/interface/IToken";
-import { IParseOptions } from "./parser/interface/IParseOptions";
-import { IParseResult } from "./parser/interface/IParseResult";
-import { ISerialiser } from "./parser/interface/ISerialiser";
-import { IMessage, MessageType } from "./parser/interface/IMessage";
+﻿import { IParser } from "./parser/interface/IParser"
+import { IToken } from "./parser/interface/IToken"
+import { IParseOptions } from "./parser/interface/IParseOptions"
+import { IParseResult } from "./parser/interface/IParseResult"
+import { ISerialiser } from "./parser/interface/ISerialiser"
+import { IMessage, MessageType } from "./parser/interface/IMessage"
 
-import { ISimulator } from "./simulator/interface/ISimulator";
-import { ICore } from "./simulator/interface/ICore";
-import { IExecutive } from "./simulator/interface/IExecutive";
-import { IPublisher } from "./simulator/interface/IPublisher";
-import { OpcodeType, ModifierType } from "./simulator/interface/IInstruction";
-import Defaults from "./simulator/Defaults";
+import { ISimulator } from "./simulator/interface/ISimulator"
+import { ICore } from "./simulator/interface/ICore"
+import { IExecutive } from "./simulator/interface/IExecutive"
+import { IPublisher } from "./simulator/interface/IPublisher"
+import { OpcodeType, ModifierType } from "./simulator/interface/IInstruction"
+import Defaults from "./simulator/Defaults"
 
-import { Parser } from "./parser/Parser";
-import { Scanner } from "./parser/Scanner";
-import { ForPass } from "./parser/ForPass";
-import { PreprocessCollector } from "./parser/PreprocessCollector";
-import { PreprocessAnalyser } from "./parser/PreprocessAnalyser";
-import { PreprocessEmitter } from "./parser/PreprocessEmitter";
-import { LabelCollector } from "./parser/LabelCollector";
-import { LabelEmitter } from "./parser/LabelEmitter";
-import { MathsProcessor } from "./parser/MathsProcessor";
-import { Expression } from "./parser/Expression";
-import { Filter } from "./parser/Filter";
-import { MetaDataCollector } from "./parser/MetaDataCollector";
-import { DefaultPass } from "./parser/DefaultPass";
-import { OrgPass } from "./parser/OrgPass";
-import { SyntaxCheck } from "./parser/SyntaxCheck";
-import { LoadFileSerialiser } from "./parser/LoadFileSerialiser";
-import { IllegalCommandCheck } from "./parser/IllegalCommandCheck";
+import { Parser } from "./parser/Parser"
+import { Scanner } from "./parser/Scanner"
+import { ForPass } from "./parser/ForPass"
+import { PreprocessCollector } from "./parser/PreprocessCollector"
+import { PreprocessAnalyser } from "./parser/PreprocessAnalyser"
+import { PreprocessEmitter } from "./parser/PreprocessEmitter"
+import { LabelCollector } from "./parser/LabelCollector"
+import { LabelEmitter } from "./parser/LabelEmitter"
+import { MathsProcessor } from "./parser/MathsProcessor"
+import { Expression } from "./parser/Expression"
+import { Filter } from "./parser/Filter"
+import { MetaDataCollector } from "./parser/MetaDataCollector"
+import { DefaultPass } from "./parser/DefaultPass"
+import { OrgPass } from "./parser/OrgPass"
+import { SyntaxCheck } from "./parser/SyntaxCheck"
+import { LoadFileSerialiser } from "./parser/LoadFileSerialiser"
+import { IllegalCommandCheck } from "./parser/IllegalCommandCheck"
 
-import { Random } from "./simulator/Random";
-import { Executive } from "./simulator/Executive";
-import { Decoder } from "./simulator/Decoder";
-import { Core } from "./simulator/Core";
-import { Loader } from "./simulator/Loader";
-import { WarriorLoader } from "./simulator/WarriorLoader";
-import { Fetcher } from "./simulator/Fetcher";
-import { Simulator } from "./simulator/Simulator";
-import { EndCondition } from "./simulator/EndCondition";
-import { OptionValidator } from "./simulator/OptionValidator";
-import { Publisher } from "./simulator/Publisher";
-import { IOptions } from "./simulator/interface/IOptions";
-import { ILoader } from "./simulator/interface/ILoader";
-import { IState } from "./simulator/interface/IState";
-import { IInstruction } from "./simulator/interface/IInstruction";
-import { IPublishProvider } from "./simulator/interface/IPublishProvider";
+import { Random } from "./simulator/Random"
+import { Executive } from "./simulator/Executive"
+import { Decoder } from "./simulator/Decoder"
+import { Core } from "./simulator/Core"
+import { Loader } from "./simulator/Loader"
+import { WarriorLoader } from "./simulator/WarriorLoader"
+import { Fetcher } from "./simulator/Fetcher"
+import { Simulator } from "./simulator/Simulator"
+import { EndCondition } from "./simulator/EndCondition"
+import { OptionValidator } from "./simulator/OptionValidator"
+import { Publisher } from "./simulator/Publisher"
+import { IOptions } from "./simulator/interface/IOptions"
+import { ILoader } from "./simulator/interface/ILoader"
+import { IState } from "./simulator/interface/IState"
+import { IInstruction } from "./simulator/interface/IInstruction"
+import { IPublishProvider } from "./simulator/interface/IPublishProvider"
 
-import * as clone from "clone";
-import { ICoreLocation } from "./simulator/interface/ICoreLocation";
+import * as clone from "clone"
+import { ICoreLocation } from "./simulator/interface/ICoreLocation"
 
 class Api {
 
-    parser: IParser;
-    serialiser: ISerialiser;
-    simulator: ISimulator;
-    core: ICore;
-    executive: IExecutive;
-    publisher: IPublisher;
+    private parser: IParser
+    private serialiser: ISerialiser
+    private simulator: ISimulator
+    private core: ICore
+    private executive: IExecutive
+    private publisher: IPublisher
 
     constructor() {
         // any setup needed for the NPM package to work properly
         // like creating the simulator and parser
-        var expression = new Expression();
+        var expression = new Expression()
 
-        this.serialiser = new LoadFileSerialiser();
+        this.serialiser = new LoadFileSerialiser()
 
         this.parser = new Parser(
             new Scanner(),
@@ -80,20 +80,20 @@ class Api {
             new DefaultPass(),
             new OrgPass(),
             new SyntaxCheck(),
-            new IllegalCommandCheck());
+            new IllegalCommandCheck())
 
-        this.publisher = new Publisher();
+        this.publisher = new Publisher()
 
-        this.core = new Core(this.publisher);
+        this.core = new Core(this.publisher)
 
         var loader = new Loader(
             new Random(),
             this.core,
-            new WarriorLoader(this.core));
+            new WarriorLoader(this.core))
 
-        var fetcher = new Fetcher();
-        this.executive = new Executive(this.publisher);
-        var decoder = new Decoder(this.executive);
+        var fetcher = new Fetcher()
+        this.executive = new Executive(this.publisher)
+        var decoder = new Decoder(this.executive)
 
         this.simulator = new Simulator(
             this.core,
@@ -103,7 +103,7 @@ class Api {
             this.executive,
             new EndCondition(this.publisher),
             new OptionValidator(),
-            this.publisher);
+            this.publisher)
     }
 
     public initialiseSimulator(opts: IOptions, parseResults: IParseResult[], messageProvider: IPublishProvider) {
@@ -113,25 +113,37 @@ class Api {
             minSeparation: opts.minSeparation,
             instructionLimit: opts.instructionLimit,
             standard: opts.standard
-        });
+        })
 
-        this.publisher.setPublishProvider(messageProvider);
+        this.publisher.setPublishProvider(messageProvider)
 
-        this.executive.initialise(options);
+        this.executive.initialise(options)
 
-        this.simulator.initialise(options, parseResults);
+        this.simulator.initialise(options, parseResults)
     }
 
     public getAt(address: number): ICoreLocation {
-        return clone(this.core.getWithInfoAt(address));
+        return clone(this.core.getWithInfoAt(address))
     }
 
     public step() : void {
-        this.simulator.step();
+        this.simulator.step()
     }
 
     public run(): void {
-        this.simulator.run();
+        this.simulator.run()
+    }
+
+    public parse(redcode: string): IParseResult {
+        return this.parser.parse(redcode)
+    }
+
+    public serialise(tokens: IToken[]) : string {
+        return this.serialiser.serialise(tokens)
+    }
+
+    public getWithInfoAt(address: number) : ICoreLocation {
+        return this.core.getWithInfoAt(address)
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.61",
+  "version": "0.0.62",
   "description": "HTML5 & javascript implementation of the classic game [corewar](https://en.wikipedia.org/wiki/Core_War)",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.63",
+  "version": "0.0.64",
   "description": "HTML5 & javascript implementation of the classic game [corewar](https://en.wikipedia.org/wiki/Core_War)",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "description": "HTML5 & javascript implementation of the classic game [corewar](https://en.wikipedia.org/wiki/Core_War)",
   "main": "./dist/index.js",
   "scripts": {


### PR DESCRIPTION
Rather than calling `corewar.parser.parse` all the methods the UI is currently using are now exposed on the root `corewar` import. So `corewar.parse()` for example.

Also updated the `d.ts` to reflect this.

Trimmed off semis as I was in that kind of mood for some reason :S