### PR TITLE
Republish messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,23 +22,38 @@ The corewar variable will initialise a new instance of the Api class ready for u
 
 ## API
 
-At the moment, the API exposed is still in flux, we anticipate the following endpoints.
+The API exposes the following functions and pubsub events:
 
-### parse(document: string, options?: IParseOptions): IParseResult
+### parse(redcode: string): IParseResult
 
-Parse a redcode document and return an IParse result which consists of the tokenised program and any associated messages.
+Parse a redcode document and return an IParseResult which consists of the tokenised program and any associated messages.
 
-### initialiseSimulator(standardId: number, parseResult: IParseResult)
+### initialiseSimulator(options: IOptions, parseResults: IParseResult[], messageProvider: IPublishProvider)
 
-Setup the simulator for a specific standard and parseResult (parsed redcode)
+Setup the simulator for a specific standard and parseResult (parsed redcode).
+Allows a pubsub provider to be specified to receive Events (see below).
 
-### step()
+### step(steps?: number): boolean
 
-Step the simulator forward one cycle
+Step the simulator forward number of cycles specified by steps (default 1).
+Returns false if the round has ended.
 
 ### run()
 
 Run the simulator to the end of the match
+
+### getWithInfoAt(address: number): ICoreLocation
+
+Return the instruction at the specified core address.
+
+### serialise(tokens: IToken[]): string
+
+Serialises the array of tokens to a single, human readable string.
+
+### republish(): void
+
+Trigger a resending of all pubsub messages for the current round.
+This can be used to build up a picture of the current state of the simulator from scratch.
 
 ## Events
 

--- a/index.ts
+++ b/index.ts
@@ -130,7 +130,7 @@ class Api {
         return clone(this.core.getWithInfoAt(address));
     }
 
-    public step(steps?: number) : boolean {
+    public step(steps?: number): boolean {
 
         return this.simulator.step(steps);
     }
@@ -145,14 +145,19 @@ class Api {
         return this.parser.parse(redcode);
     }
 
-    public serialise(tokens: IToken[]) : string {
+    public serialise(tokens: IToken[]): string {
 
         return this.serialiser.serialise(tokens);
     }
 
-    public getWithInfoAt(address: number) : ICoreLocation {
+    public getWithInfoAt(address: number): ICoreLocation {
 
         return this.core.getWithInfoAt(address);
+    }
+
+    public republish(): void {
+
+        this.publisher.republish();
     }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -125,11 +125,6 @@ class Api {
         this.simulator.initialise(options, parseResults);
     }
 
-    public getAt(address: number): ICoreLocation {
-
-        return clone(this.core.getWithInfoAt(address));
-    }
-
     public step(steps?: number): boolean {
 
         return this.simulator.step(steps);
@@ -150,9 +145,10 @@ class Api {
         return this.serialiser.serialise(tokens);
     }
 
+    //TODO I think we should rename this to getAt
     public getWithInfoAt(address: number): ICoreLocation {
 
-        return this.core.getWithInfoAt(address);
+        return clone(this.core.getWithInfoAt(address));
     }
 
     public republish(): void {

--- a/simulator/LatestOnlyStrategy.ts
+++ b/simulator/LatestOnlyStrategy.ts
@@ -26,4 +26,9 @@ export class LatestOnlyStrategy implements IPublishStrategy {
 
         return message;
     }
+
+    public clear(): void {
+
+        this.message = null;
+    }
 }

--- a/simulator/LatestOnlyStrategy.ts
+++ b/simulator/LatestOnlyStrategy.ts
@@ -22,7 +22,6 @@ export class LatestOnlyStrategy implements IPublishStrategy {
         }
 
         const message = this.message;
-        this.message = null;
 
         return message;
     }

--- a/simulator/PerKeyStrategy.ts
+++ b/simulator/PerKeyStrategy.ts
@@ -34,4 +34,9 @@ export class PerKeyStrategy implements IPublishStrategy {
             payload: payloads
         };
     }
+
+    public clear(): void {
+
+        this.payloads = {};
+    }
 }

--- a/simulator/PerKeyStrategy.ts
+++ b/simulator/PerKeyStrategy.ts
@@ -27,8 +27,6 @@ export class PerKeyStrategy implements IPublishStrategy {
             return null;
         }
 
-        this.payloads = {};
-
         return {
             type: this.type,
             payload: payloads

--- a/simulator/Publisher.ts
+++ b/simulator/Publisher.ts
@@ -53,4 +53,12 @@ export class Publisher implements IPublisher {
                 );
             });
     }
+
+    public clear(): void {
+
+        this.publishStrategies
+            .forEach(s => {
+                s.clear();
+            });
+    }
 }

--- a/simulator/Publisher.ts
+++ b/simulator/Publisher.ts
@@ -58,7 +58,7 @@ export class Publisher implements IPublisher {
             return;
         }
 
-        this.publishStrategies
+        strategies
             .forEach(s => {
                 
                 var message = s.dequeue();
@@ -77,6 +77,11 @@ export class Publisher implements IPublisher {
     public clear(): void {
 
         this.publishStrategies
+            .forEach(s => {
+                s.clear();
+            });
+
+        this.republishStrategies
             .forEach(s => {
                 s.clear();
             });

--- a/simulator/Simulator.ts
+++ b/simulator/Simulator.ts
@@ -70,6 +70,8 @@ export class Simulator implements ISimulator {
 
     public initialise(options: IOptions, warriors: IParseResult[]) {
 
+        this.publisher.clear();
+
         this.initState();
 
         const defaultedOptions = Object.assign({}, Defaults, options);

--- a/simulator/interface/IPublishStrategy.ts
+++ b/simulator/interface/IPublishStrategy.ts
@@ -4,4 +4,5 @@ export interface IPublishStrategy {
 
     queue(message: IMessage): void;
     dequeue(): IMessage;
+    clear(): void;
 }

--- a/simulator/interface/IPublisher.ts
+++ b/simulator/interface/IPublisher.ts
@@ -5,5 +5,6 @@ export interface IPublisher {
     
     queue(message: IMessage): void;
     publish(): void;
+    clear(): void;
     setPublishProvider(publishProvider: IPublishProvider): void;
 }

--- a/simulator/interface/IPublisher.ts
+++ b/simulator/interface/IPublisher.ts
@@ -5,6 +5,7 @@ export interface IPublisher {
     
     queue(message: IMessage): void;
     publish(): void;
+    republish(): void;
     clear(): void;
     setPublishProvider(publishProvider: IPublishProvider): void;
 }

--- a/simulator/tests/CoreTests.ts
+++ b/simulator/tests/CoreTests.ts
@@ -13,6 +13,7 @@ import { ICore, ICoreAccessEventArgs, CoreAccessType } from "../interface/ICore"
 import Defaults from "../Defaults";
 import { MessageType } from "../interface/IMessage";
 import { IPublisher } from "../interface/IPublisher";
+import TestHelper from "./TestHelper";
 
 describe("Core", () => {
 
@@ -51,11 +52,7 @@ describe("Core", () => {
 
     beforeEach(() => {
 
-        publisher = {
-            queue: sinon.stub(),
-            publish: sinon.stub(),
-            setPublishProvider: sinon.stub()
-        };
+        publisher = TestHelper.buildPublisher();
     });
 
     it("Initialises core to the required size and provides accessor methods", () => {

--- a/simulator/tests/EndConditionTests.ts
+++ b/simulator/tests/EndConditionTests.ts
@@ -55,11 +55,7 @@ describe("EndCondition", () => {
     let publisher: IPublisher;
 
     beforeEach(() => {
-        publisher = {
-            queue: sinon.stub(),
-            publish: sinon.stub(),
-            setPublishProvider: sinon.stub()
-        };
+        publisher = TestHelper.buildPublisher();
     });
 
     it("returns false if there are multiple active warriors and the maximum number of cycles has not elapsed", () => {

--- a/simulator/tests/ExecutiveTests.ts
+++ b/simulator/tests/ExecutiveTests.ts
@@ -20,11 +20,7 @@ describe("Executive", () => {
 
     beforeEach(() => {
 
-        publisher = {
-            queue: sinon.stub(),
-            publish: sinon.stub(),
-            setPublishProvider: sinon.stub()
-        };
+        publisher = TestHelper.buildPublisher();
 
         this.executive = new Executive(publisher);
     });

--- a/simulator/tests/LatestOnlyStrategyTests.ts
+++ b/simulator/tests/LatestOnlyStrategyTests.ts
@@ -26,7 +26,7 @@ describe("LatestOnlyStrategy", () => {
         expect(strategy.dequeue()).to.be.deep.equal(expected);
     });
 
-    it("returns null if dequeued a second time without queueing", () => {
+    it("returns same message if dequeued a second time without queueing", () => {
 
         const strategy = new LatestOnlyStrategy();
 
@@ -35,7 +35,7 @@ describe("LatestOnlyStrategy", () => {
         strategy.queue(message);
         strategy.dequeue();
 
-        expect(strategy.dequeue()).to.be.null;
+        expect(strategy.dequeue()).to.be.deep.equal(message);
     });
 
     it("returns null if cleared and then dequeued", () => {

--- a/simulator/tests/LatestOnlyStrategyTests.ts
+++ b/simulator/tests/LatestOnlyStrategyTests.ts
@@ -37,4 +37,16 @@ describe("LatestOnlyStrategy", () => {
 
         expect(strategy.dequeue()).to.be.null;
     });
+
+    it("returns null if cleared and then dequeued", () => {
+
+        const strategy = new LatestOnlyStrategy();
+
+        const unexpected = { type: MessageType.CoreAccess, payload: {} };
+
+        strategy.queue(unexpected);
+        strategy.clear();
+
+        expect(strategy.dequeue()).to.be.null;
+    });
 });

--- a/simulator/tests/PerKeyStrategyTests.ts
+++ b/simulator/tests/PerKeyStrategyTests.ts
@@ -29,7 +29,7 @@ describe("PerKeyStrategy", () => {
         });
     });
 
-    it("returns null if dequeued a second time without queueing", () => {
+    it("returns the same queued message if dequeued a second time without queueing", () => {
 
         const strategy = new PerKeyStrategy(p => p.address);
 
@@ -38,7 +38,10 @@ describe("PerKeyStrategy", () => {
         strategy.queue(message);
         strategy.dequeue();
 
-        expect(strategy.dequeue()).to.be.null;
+        expect(strategy.dequeue()).to.be.deep.equal({
+            type: MessageType.CoreAccess,
+            payload: [ message.payload ]
+        });
     });
 
     it("returns a payload for each unique address", () => {

--- a/simulator/tests/PerKeyStrategyTests.ts
+++ b/simulator/tests/PerKeyStrategyTests.ts
@@ -58,4 +58,16 @@ describe("PerKeyStrategy", () => {
             payload: [payload1, payload2, payload3]
         });
     });
+
+    it("returns null if cleared and then dequeued", () => {
+
+        const strategy = new PerKeyStrategy(p => p.address);
+
+        const message = { type: MessageType.CoreAccess, payload: { address: 1 } };
+
+        strategy.queue(message);
+        strategy.clear();
+
+        expect(strategy.dequeue()).to.be.null;
+    });
 });

--- a/simulator/tests/PublisherTests.ts
+++ b/simulator/tests/PublisherTests.ts
@@ -168,6 +168,7 @@ describe("Publisher", () => {
 
         publisher.clear();
 
-        expect(strategy.clear).to.have.callCount(strategies.length);
+        // *2 because there is a publish and a republish clone of each strategy
+        expect(strategy.clear).to.have.callCount(strategies.length * 2);
     });
 });

--- a/simulator/tests/PublisherTests.ts
+++ b/simulator/tests/PublisherTests.ts
@@ -102,4 +102,29 @@ describe("Publisher", () => {
         expect(provider.publishSync).to.have.been.calledWith("CORE_INITIALISE", initialiseMessages.payload);
         expect(provider.publishSync).to.have.been.calledWith("ROUND_START", roundStartMessages.payload);
     });
+
+    it("clears all strategies when .clear is called", () => {
+
+        const strategy = buildStrategy();
+
+        const expectedPayload = {
+            type: MessageType.TaskCount,
+            payload: {}
+        };
+
+        const strategies = [
+            strategy,
+            strategy,
+            strategy,
+            strategy,
+            strategy,
+            strategy
+        ];
+
+        const publisher = new Publisher(strategies);
+
+        publisher.clear();
+
+        expect(strategy.clear).to.have.callCount(strategies.length);
+    });
 });

--- a/simulator/tests/PublisherTests.ts
+++ b/simulator/tests/PublisherTests.ts
@@ -6,6 +6,7 @@ chai.use(sinonChai);
 
 import { Publisher } from "../Publisher";
 import { MessageType } from "../interface/IMessage";
+import { start } from "repl";
 
 describe("Publisher", () => {
 
@@ -64,13 +65,14 @@ describe("Publisher", () => {
         publisher.queue(expectedPayload);
 
         expect(expectedStrategy.queue).to.have.been.calledWith(expectedPayload);
+        expect(expectedStrategy.queue).to.have.callCount(2);
 
         expect(expectedStrategy.dequeue).not.to.have.been.called;
         expect(unexpected.queue).not.to.have.been.called;
         expect(unexpected.dequeue).not.to.have.been.called;
     });
 
-    it("publishes all queued messages by dequeueing all strategies", () => {
+    it("publishes all queued messages by dequeueing and clearing all strategies", () => {
 
         const coreAccessMessages = { type: MessageType.CoreAccess, payload: [{}] };
         const runProgressMessages = { type: MessageType.RunProgress, payload: [{}] };
@@ -101,6 +103,47 @@ describe("Publisher", () => {
         expect(provider.publishSync).to.have.been.calledWith("TASK_COUNT", taskCountMessages.payload);
         expect(provider.publishSync).to.have.been.calledWith("CORE_INITIALISE", initialiseMessages.payload);
         expect(provider.publishSync).to.have.been.calledWith("ROUND_START", roundStartMessages.payload);
+
+        strategies.forEach(s => {
+            expect(s.clear).to.have.been.called;
+        })
+    });
+
+    it("republishes all queued messages by dequeueing all strategies but NOT clearing them", () => {
+
+        const coreAccessMessages = { type: MessageType.CoreAccess, payload: [{}] };
+        const runProgressMessages = { type: MessageType.RunProgress, payload: [{}] };
+        const roundEndMessages = { type: MessageType.RoundEnd, payload: [{}] };
+        const taskCountMessages = { type: MessageType.TaskCount, payload: [{ a: "a" }, { b: "b" }] };
+        const initialiseMessages = { type: MessageType.CoreInitialise, payload: [{}] };
+        const roundStartMessages = { type: MessageType.RoundStart, payload: [{}] };
+
+        const strategies = [
+            { dequeue: sinon.stub().returns(coreAccessMessages), queue: sinon.stub(), clear: sinon.stub() },
+            { dequeue: sinon.stub().returns(runProgressMessages), queue: sinon.stub(), clear: sinon.stub() },
+            { dequeue: sinon.stub().returns(roundEndMessages), queue: sinon.stub(), clear: sinon.stub() },
+            { dequeue: sinon.stub().returns(taskCountMessages), queue: sinon.stub(), clear: sinon.stub() },
+            { dequeue: sinon.stub().returns(initialiseMessages), queue: sinon.stub(), clear: sinon.stub() },
+            { dequeue: sinon.stub().returns(roundStartMessages), queue: sinon.stub(), clear: sinon.stub() }
+        ];
+
+        const provider = { publishSync: sinon.stub() };
+
+        const publisher = new Publisher(strategies);
+        publisher.setPublishProvider(provider);
+
+        publisher.republish();
+
+        expect(provider.publishSync).to.have.been.calledWith("CORE_ACCESS", coreAccessMessages.payload);
+        expect(provider.publishSync).to.have.been.calledWith("RUN_PROGRESS", runProgressMessages.payload);
+        expect(provider.publishSync).to.have.been.calledWith("ROUND_END", roundEndMessages.payload);
+        expect(provider.publishSync).to.have.been.calledWith("TASK_COUNT", taskCountMessages.payload);
+        expect(provider.publishSync).to.have.been.calledWith("CORE_INITIALISE", initialiseMessages.payload);
+        expect(provider.publishSync).to.have.been.calledWith("ROUND_START", roundStartMessages.payload);
+
+        strategies.forEach(s => {
+            expect(s.clear).not.to.have.been.called;
+        })
     });
 
     it("clears all strategies when .clear is called", () => {

--- a/simulator/tests/PublisherTests.ts
+++ b/simulator/tests/PublisherTests.ts
@@ -9,6 +9,14 @@ import { MessageType } from "../interface/IMessage";
 
 describe("Publisher", () => {
 
+    function buildStrategy() {
+        return {
+            queue: sinon.stub(),
+            dequeue: sinon.stub(),
+            clear: sinon.stub()
+        };
+    }
+
     it("can be called when the publish provider has not been specified", () => {
 
         const publisher = new Publisher([]);
@@ -33,14 +41,8 @@ describe("Publisher", () => {
 
     it("queues messages with the relevant publish strategy", () => {
 
-        const unexpected = {
-            queue: sinon.stub(),
-            dequeue: sinon.stub()
-        };
-        const expectedStrategy = {
-            queue: sinon.stub(),
-            dequeue: sinon.stub()
-        };
+        const unexpected = buildStrategy();
+        const expectedStrategy = buildStrategy();
 
         const expectedPayload = {
             type: MessageType.TaskCount,
@@ -78,12 +80,12 @@ describe("Publisher", () => {
         const roundStartMessages = { type: MessageType.RoundStart, payload: [{}] };
 
         const strategies = [
-            { dequeue: sinon.stub().returns(coreAccessMessages), queue: sinon.stub() },
-            { dequeue: sinon.stub().returns(runProgressMessages), queue: sinon.stub() },
-            { dequeue: sinon.stub().returns(roundEndMessages), queue: sinon.stub() },
-            { dequeue: sinon.stub().returns(taskCountMessages), queue: sinon.stub() },
-            { dequeue: sinon.stub().returns(initialiseMessages), queue: sinon.stub() },
-            { dequeue: sinon.stub().returns(roundStartMessages), queue: sinon.stub() }
+            { dequeue: sinon.stub().returns(coreAccessMessages), queue: sinon.stub(), clear: sinon.stub() },
+            { dequeue: sinon.stub().returns(runProgressMessages), queue: sinon.stub(), clear: sinon.stub() },
+            { dequeue: sinon.stub().returns(roundEndMessages), queue: sinon.stub(), clear: sinon.stub() },
+            { dequeue: sinon.stub().returns(taskCountMessages), queue: sinon.stub(), clear: sinon.stub() },
+            { dequeue: sinon.stub().returns(initialiseMessages), queue: sinon.stub(), clear: sinon.stub() },
+            { dequeue: sinon.stub().returns(roundStartMessages), queue: sinon.stub(), clear: sinon.stub() }
         ];
 
         const provider = { publishSync: sinon.stub() };

--- a/simulator/tests/SimulatorTests.ts
+++ b/simulator/tests/SimulatorTests.ts
@@ -100,13 +100,7 @@ describe("Simulator", () => {
             validate: sinon.stub()
         };
 
-        publisher = {
-            queue: sinon.stub(),
-            publish: sinon.stub(),
-            republish: sinon.stub(),
-            clear: sinon.stub(),
-            setPublishProvider: sinon.stub()
-        };
+        publisher = TestHelper.buildPublisher();
 
         simulator = new Simulator(
             core,

--- a/simulator/tests/SimulatorTests.ts
+++ b/simulator/tests/SimulatorTests.ts
@@ -103,6 +103,8 @@ describe("Simulator", () => {
         publisher = {
             queue: sinon.stub(),
             publish: sinon.stub(),
+            republish: sinon.stub(),
+            clear: sinon.stub(),
             setPublishProvider: sinon.stub()
         };
 
@@ -469,4 +471,11 @@ describe("Simulator", () => {
             }
         });
     });
+
+    it("clears Publisher on initialise", () => {
+
+        simulator.initialise(clone(Defaults), []);
+
+        expect(publisher.clear).to.have.been.called;
+    })
 });

--- a/simulator/tests/TestHelper.ts
+++ b/simulator/tests/TestHelper.ts
@@ -10,6 +10,7 @@ import { ModeType } from "../interface/IOperand";
 import { IInstruction } from "../interface/IInstruction";
 import { ICore } from "../interface/ICore";
 import { IOptions } from "../interface/IOptions";
+import { IPublisher } from "../interface/IPublisher";
 
 "use strict";
 
@@ -19,6 +20,17 @@ export default class TestHelper {
         line: 1,
         char: 1
     };
+
+    public static buildPublisher(): IPublisher {
+
+        return {
+            queue: sinon.stub(),
+            publish: sinon.stub(),
+            republish: sinon.stub(),
+            clear: sinon.stub(),
+            setPublishProvider: sinon.stub()
+        };
+    }
 
     public static buildParseResult(tokens: IToken[]): IParseResult {
         return {


### PR DESCRIPTION
Implements #155 

Added a new method to the module's index.ts `republish(): void` which will resend the messages needed to redraw the core canvas from scratch.

This works by keeping a second copy of queued messages which persists between calls to step.  This second copy of messages is cleared when `initialise` is called.

Did a quick test against the UI project and all seems to be working as before so hopefully no regression impact but won't know for sure if the new functionality is working until it's integrated into the UI!