### PR TITLE
Parse result data

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Parse a redcode document and return an IParseResult which consists of the tokeni
 ### initialiseSimulator(options: IOptions, parseResults: IParseResult[], messageProvider: IPublishProvider)
 
 Setup the simulator for a specific standard and parseResult (parsed redcode).
+IParseResults are produced as output from the Parser module.
+Additional, data can be associated with a warrior when it is loaded into core by adding a data property to the parseResults given to the initialise function.
 Allows a pubsub provider to be specified to receive Events (see below).
 
 ### step(steps?: number): boolean
@@ -76,6 +78,7 @@ Published when a warrior reads to, writes from or executes within the core
 ```
 [{
   warriorId: number,      // Each warrior has a unique id
+  warriorData?: any,      // Any data supplied with this warrior's initial parse result
   accessType: AccessType, // AccessType can be 0=read, 1=write or 2=execute
   address: number         // Absolute address within the core
 }]
@@ -98,7 +101,8 @@ Published at the end of the round to indicate the outcome
 ```
 {
   winnerId: number,  // The unique id of the winning warrior or null
-  outcome: string     // Can be 'WIN', 'DRAW' or 'NONE'. 'NONE' indicates a single warrior battle
+  winnerData?: any,  // Any data supplied with this warrior's initial parse result
+  outcome: string    // Can be 'WIN', 'DRAW' or 'NONE'. 'NONE' indicates a single warrior battle
 }
 ```
 
@@ -109,6 +113,7 @@ Published whenever a warrior creates or loses a task.
 ```
 [{
   warriorId: number,  // The unique id of the warrior
+  warriorData?: any,  // Any data supplied with this warrior's initial parse result
   taskCount: number   // The warrior's current task count
 }]
 ```
@@ -120,6 +125,7 @@ Published once per call to step and indicates the next address which will be exe
 ```
 {
   warriorId: number,  // The unique id of the next warrior
+  warriorData?: any,  // Any data supplied with this warrior's initial parse result
   address: number     // The address in core at which the next warrior will execute
 }
 ```

--- a/parser/interface/IParseResult.ts
+++ b/parser/interface/IParseResult.ts
@@ -7,5 +7,5 @@ export interface IParseResult {
     metaData: IMetaData;
     tokens: IToken[];
     messages: IMessage[];
-    data: any;
+    data?: any;
 } 

--- a/parser/interface/IParseResult.ts
+++ b/parser/interface/IParseResult.ts
@@ -7,4 +7,5 @@ export interface IParseResult {
     metaData: IMetaData;
     tokens: IToken[];
     messages: IMessage[];
+    data: any;
 } 

--- a/simulator/Core.ts
+++ b/simulator/Core.ts
@@ -48,6 +48,9 @@ export class Core implements ICore {
             accessType: accessType,
             address: address
         };
+        if (task && task.warrior.data) {
+            accessEventArgs["warriorData"] = task.warrior.data;
+        }
 
         this.locations[address].access = accessEventArgs;
 

--- a/simulator/EndCondition.ts
+++ b/simulator/EndCondition.ts
@@ -13,7 +13,7 @@ export class EndCondition implements IEndCondition {
         this.publisher = publisher;
     }
 
-    private publishRoundEnd(outcome: string, winnerId: number = null) {
+    private publishRoundEnd(outcome: string, winner: IWarrior = null) {
 
         this.publisher.queue({
             type: MessageType.RunProgress,
@@ -22,12 +22,17 @@ export class EndCondition implements IEndCondition {
             }
         });
 
+        const payload =  {
+            winnerId: winner && winner.id,
+            outcome
+        };
+        if (winner && winner.data) {
+            payload["winnerData"] = winner.data;
+        }
+
         this.publisher.queue({
             type: MessageType.RoundEnd,
-            payload: {
-                winnerId,
-                outcome
-            }
+            payload
         });
     }
 
@@ -61,7 +66,7 @@ export class EndCondition implements IEndCondition {
                 return true;
             }
         } else if (liveWarriors.length === 1) {
-            this.publishRoundEnd('WIN', liveWarriors[0].id);
+            this.publishRoundEnd('WIN', liveWarriors[0]);
             return true;
         }
 

--- a/simulator/Executive.ts
+++ b/simulator/Executive.ts
@@ -5,6 +5,7 @@ import { IOptions } from "./interface/IOptions";
 import { MessageType } from "./interface/IMessage";
 import { IPublisher } from "./interface/IPublisher";
 import { IOperand } from "./interface/IOperand";
+import { IWarrior } from "./interface/IWarrior";
 
 export class Executive implements IExecutive {
 
@@ -42,14 +43,19 @@ export class Executive implements IExecutive {
         this.maxTasks = options.maxTasks;
     }
 
-    private publishTaskCount(warriorId: number, taskCount: number) {
+    private publishTaskCount(warrior: IWarrior, taskCount: number) {
+
+        const payload = {
+            warriorId: warrior.id,
+            taskCount
+        };
+        if (warrior.data) {
+            payload["warriorData"] = warrior.data;
+        }
 
         this.publisher.queue({
             type: MessageType.TaskCount,
-            payload: {
-                warriorId,
-                taskCount
-            }
+            payload
         });
     }
 
@@ -61,7 +67,7 @@ export class Executive implements IExecutive {
         // we just chomped off the last task
         context.warrior.taskIndex = ti % context.warrior.tasks.length;
 
-        this.publishTaskCount(context.warrior.id, context.warrior.tasks.length);
+        this.publishTaskCount(context.warrior, context.warrior.tasks.length);
     }
 
     private mov(context: IExecutionContext) {
@@ -290,7 +296,7 @@ export class Executive implements IExecutive {
             });
             context.warrior.taskIndex = (context.warrior.taskIndex + 1) % context.warrior.tasks.length;
 
-            this.publishTaskCount(context.warrior.id, context.warrior.tasks.length);
+            this.publishTaskCount(context.warrior, context.warrior.tasks.length);
         }
     }
 

--- a/simulator/Warrior.ts
+++ b/simulator/Warrior.ts
@@ -15,6 +15,8 @@ export class Warrior implements IWarrior {
 
     public startAddress: number;
 
+    public data: any;
+
     constructor() {
         this.id = 0;
         this.name = "";
@@ -23,5 +25,6 @@ export class Warrior implements IWarrior {
         this.taskIndex = 0;
         this.tasks = [];
         this.startAddress = 0;
+        this.data = null;
     }
 }

--- a/simulator/WarriorLoader.ts
+++ b/simulator/WarriorLoader.ts
@@ -225,12 +225,17 @@ export class WarriorLoader implements IWarriorLoader {
         this.warrior.startAddress = startAddress;
         this.warrior.taskIndex = 0;
 
+        const payload =  {
+            warriorId: this.warrior.id,
+            taskCount: 1
+        };
+        if (this.warrior.data) {
+            payload["warriorData"] = this.warrior.data;
+        }
+
         this.publisher.queue({
             type: MessageType.TaskCount,
-            payload: {
-                warriorId: this.warrior.id,
-                taskCount: 1
-            }
+            payload
         });
     }
 }

--- a/simulator/WarriorLoader.ts
+++ b/simulator/WarriorLoader.ts
@@ -15,6 +15,8 @@ import { Warrior } from "./Warrior";
 import { IPublisher } from "./interface/IPublisher";
 import { MessageType } from "./interface/IMessage";
 
+import * as clone from "clone";
+
 export class WarriorLoader implements IWarriorLoader {
 
     private address: number;
@@ -41,6 +43,7 @@ export class WarriorLoader implements IWarriorLoader {
         this.warrior.name = result.metaData.name;
         this.warrior.author = result.metaData.author;
         this.warrior.strategy = result.metaData.strategy;
+        this.warrior.data = clone(result.data);
         
         this.loadProcess(address);
 

--- a/simulator/interface/IWarrior.ts
+++ b/simulator/interface/IWarrior.ts
@@ -13,5 +13,5 @@ export interface IWarrior {
 
     startAddress: number;
 
-    data: any;
+    data?: any;
 } 

--- a/simulator/interface/IWarrior.ts
+++ b/simulator/interface/IWarrior.ts
@@ -12,4 +12,6 @@ export interface IWarrior {
     tasks: ITask[];
 
     startAddress: number;
+
+    data: any;
 } 

--- a/simulator/tests/CoreTests.ts
+++ b/simulator/tests/CoreTests.ts
@@ -33,11 +33,12 @@ describe("Core", () => {
         };
     }
 
-    function buildTask(warriorId: number = 0): ITask {
+    function buildTask(warriorId: number = 0, data: any = null): ITask {
         return {
             instructionPointer: 0,
             warrior: {
                 id: warriorId,
+                data: data,
                 author: "",
                 name: "",
                 startAddress: 0,
@@ -262,6 +263,34 @@ describe("Core", () => {
         core.executeAt(task, 2);
 
         expect(publisher.queue).not.to.have.been.called;
+    });
+
+    it("includes warrior data if provided when triggering a core access event", () => {
+
+        const expected = {
+            foo: "foo",
+            bar: x => {
+                x = x + 1;
+                return x;
+            }
+        };
+
+        const task = buildTask(5, expected);
+
+        const core = new Core(publisher);
+        core.initialise(Object.assign({}, Defaults, { coresize: 4 }));
+
+        core.setAt(task, 2, buildInstruction());
+
+        expect(publisher.queue).to.have.been.calledWith({
+            type: MessageType.CoreAccess,
+            payload: {
+                warriorId: task.warrior.id,
+                warriorData: expected,
+                accessType: CoreAccessType.write,
+                address: 2
+            }
+        });
     });
 
     it(".getSize returns the size of the core", () => {

--- a/simulator/tests/EndConditionTests.ts
+++ b/simulator/tests/EndConditionTests.ts
@@ -192,6 +192,34 @@ describe("EndCondition", () => {
         });
     });
 
+    it("includes warrior data in round end message if a warrior wins", () => {
+
+        const state = buildState();
+
+        const expected = {
+            foo: "foo",
+            bar: x => x + 1
+        };
+
+        state.warriors[0].id = 5;
+        state.warriors[1].id = 7;
+        state.warriors[1].data = expected;
+        state.warriors[0].tasks = [];
+
+        const endCondition = new EndCondition(publisher);
+
+        endCondition.check(state);
+
+        expect(publisher.queue).to.have.been.calledWith({
+            type: MessageType.RoundEnd,
+            payload: {
+                winnerId: 7,
+                winnerData: expected,
+                outcome: 'WIN'
+            }
+        });
+    });
+
     it("publishes round end message if single warrior round ends", () => {
 
         const state = buildState();

--- a/simulator/tests/ExecutiveTestHelper.ts
+++ b/simulator/tests/ExecutiveTestHelper.ts
@@ -72,7 +72,7 @@ export function buildContext(testConfig: IExecutiveTestConfig): IExecutionContex
 }
 
 function buildWarrior(testConfig: IExecutiveTestConfig): IWarrior {
-    const warrior = TestHelper.buildWarrior(7);
+    const warrior = TestHelper.buildWarrior(7, { data: "true" });
     warrior.tasks = [];
     for (let i = 0; i < (testConfig.taskCount || 3); i++) {
         warrior.tasks.push(TestHelper.buildTask());

--- a/simulator/tests/ExecutiveTests.ts
+++ b/simulator/tests/ExecutiveTests.ts
@@ -42,6 +42,7 @@ describe("Executive", () => {
                 type: MessageType.TaskCount,
                 payload: {
                     warriorId: context.warrior.id,
+                    warriorData: { data: "true" },
                     taskCount: expectation.taskCount
                 }
             });
@@ -327,6 +328,7 @@ describe("Executive", () => {
                 type: MessageType.TaskCount,
                 payload: {
                     warriorId: context.warrior.id,
+                    warriorData: { data: "true" },
                     taskCount: expectation.taskCount
                 }
             });

--- a/simulator/tests/TestHelper.ts
+++ b/simulator/tests/TestHelper.ts
@@ -73,9 +73,10 @@ export default class TestHelper {
         ];
     }
 
-    public static buildWarrior(id: number = 0): IWarrior {
+    public static buildWarrior(id: number = 0, data: any = null): IWarrior {
         return {
             id: id,
+            data: data,
             author: "",
             name: "",
             startAddress: 0,

--- a/simulator/tests/WarriorLoaderTests.ts
+++ b/simulator/tests/WarriorLoaderTests.ts
@@ -408,6 +408,31 @@ describe("WarriorLoader", () => {
         });
     });
 
+    it("includes warrior data when publishing initial task count of 1", () => {
+
+        const expectedData = {
+            foo: "foo",
+            array: [ 1, 2, 3 ]
+        };
+        const expectedId = 5;
+        const core = buildCore(0);
+        const tokens = TestHelper.buildParseResult(instruction("MOV", ".I", "$", 0, "$", 1));
+        const loader = new WarriorLoader(core, this.publisher);
+
+        tokens.data = expectedData;
+
+        loader.load(0, tokens, expectedId);
+
+        expect(this.publisher.queue).to.have.been.calledWith({
+            type: MessageType.TaskCount,
+            payload: {
+                warriorId: expectedId,
+                warriorData: expectedData,
+                taskCount: 1
+            }
+        });
+    });
+
     it("clones and stores the IParseResult data against the new Warrior instance", () => {
 
         const expected = {

--- a/simulator/tests/WarriorLoaderTests.ts
+++ b/simulator/tests/WarriorLoaderTests.ts
@@ -406,5 +406,26 @@ describe("WarriorLoader", () => {
                 taskCount: 1
             }
         });
-    })
+    });
+
+    it("clones and stores the IParseResult data against the new Warrior instance", () => {
+
+        const expected = {
+            foo: 'foo',
+            bar: x => {
+                return x;
+            }
+        };
+
+        const tokens = TestHelper.buildParseResult(instruction("MOV", ".I", "$", 0, "$", 1));
+        const core = buildCore(0);
+
+        tokens.data = expected;
+
+        const loader = new WarriorLoader(core, this.publisher);
+        
+        const actual = loader.load(0, tokens, 0);
+
+        expect(actual.data).to.be.deep.equal(expected);
+    });
 });


### PR DESCRIPTION
Allow optional `data: any` property to be included with `IParseResult` supplied to `Simulator`.
Data should be able to contain anything (including lambdas, nested objects, arrays, etc.).

Resolves #168 

The warrior's data is echoed back in the payload of the following pubsub messages:

- CORE_ACCESS
- ROUND_END
- TASK_COUNT
- NEXT_EXECUTION
