### PR TITLE
Unsigned arithmancy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -452,6 +452,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1069,6 +1070,535 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "gauge": {
       "version": "1.2.7",
@@ -1770,6 +2300,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "dev": true,
+      "optional": true
     },
     "nise": {
       "version": "1.2.0",

--- a/simulator/Decoder.ts
+++ b/simulator/Decoder.ts
@@ -148,7 +148,7 @@ export class Decoder implements IDecoder {
 
         const address = ipa + --value;
 
-        instruction.aOperand.address = value;
+        instruction.aOperand.address = core.wrap(value);
         core.setAt(task, ipa, instruction);
 
         return clone(core.getAt(address));
@@ -164,7 +164,7 @@ export class Decoder implements IDecoder {
 
         const address = ipa + --value;
 
-        instruction.bOperand.address = value;
+        instruction.bOperand.address = core.wrap(value);
         core.setAt(task, ipa, instruction);
 
         return clone(core.getAt(address));
@@ -182,7 +182,7 @@ export class Decoder implements IDecoder {
 
         const result = clone(core.getAt(address));
 
-        instruction.aOperand.address = value;
+        instruction.aOperand.address = core.wrap(value);
         core.setAt(task, ipa, instruction);
 
         return result;
@@ -200,7 +200,7 @@ export class Decoder implements IDecoder {
 
         const result = clone(core.getAt(address));
 
-        instruction.bOperand.address = value;
+        instruction.bOperand.address = core.wrap(value);
         core.setAt(task, ipa, instruction);
 
         return result;

--- a/simulator/WarriorLoader.ts
+++ b/simulator/WarriorLoader.ts
@@ -182,7 +182,7 @@ export class WarriorLoader implements IWarriorLoader {
 
         var result: IOperand = {
             mode: 0,
-            address: parseInt(operand.address.lexeme, 10)
+            address: this.core.wrap(parseInt(operand.address.lexeme, 10))
         };
 
         switch (operand.mode.lexeme) {

--- a/simulator/tests/DecoderTests.ts
+++ b/simulator/tests/DecoderTests.ts
@@ -54,7 +54,7 @@ describe("Decoder", () => {
         { core: ["NOP.I $1, $2", "ADD.AB {-1, {1", "DAT.F $0, $6"], ip: 1, e: ["NOP.I $0, $2", "ADD.AB {-1, {1"] },
         { core: ["NOP.I $2, $1", "ADD.AB <-1, <1", "DAT.F $5, $0"], ip: 1, e: ["NOP.I $2, $0", "ADD.AB <-1, <1"] },
         { core: ["NOP.I $1, $2", "ADD.AB }-1, }1", "DAT.F $0, $6"], ip: 1, e: ["ADD.AB }-1, }1", "DAT.F $0, $6"] },
-        { core: ["NOP.I $2, $0", "ADD.AB >-1, >1", "DAT.F $5, $-1"], ip: 1, e: ["NOP.I $2, $0", "ADD.AB >-1, >1"] },
+        { core: ["NOP.I $2, $0", "ADD.AB >-1, >1", "DAT.F $5, $-1"], ip: 1, e: ["NOP.I $2, $0", "ADD.AB >-1, >1"] }
     ],
         (context, expectation) => {
 

--- a/simulator/tests/TestHelper.ts
+++ b/simulator/tests/TestHelper.ts
@@ -121,6 +121,9 @@ export default class TestHelper {
 
         const wrapStub = sinon.stub();
         wrapStub.callsFake((address: number) => {
+            address = address % size;
+            address = address >= 0 ? address : address + size;
+
             return address;
         });
 

--- a/simulator/tests/WarriorLoaderTests.ts
+++ b/simulator/tests/WarriorLoaderTests.ts
@@ -21,6 +21,8 @@ import { MessageType } from "../interface/IMessage";
 
 describe("WarriorLoader", () => {
 
+    const CORESIZE = 8000;
+
     var instruction = TestHelper.instruction;
 
     var testTokens = instruction("DAT", ".A", "$", 0, "$", 1)
@@ -58,8 +60,11 @@ describe("WarriorLoader", () => {
             initialise: (options: IOptions) => {
                 //
             },
-            wrap: (index: number): number => {
-                return index;
+            wrap: (address: number): number => {
+                address = address % CORESIZE;
+                address = address >= 0 ? address : address + CORESIZE;
+
+                return address;
             },
             executeAt: (task: ITask, index: number): IInstruction => {
                 return core.instructions[index];
@@ -177,6 +182,21 @@ describe("WarriorLoader", () => {
         }
     });
 
+    it("applies wraps addresses so that they are in the range 0-(CORESIZE-1)", () => {
+
+        const tokens = TestHelper.buildParseResult(instruction("MOV", ".I", "$", -1, "$", 8001));
+        const core = buildCore(30);
+
+        const loader = new WarriorLoader(core, this.publisher);
+        debugger;
+        loader.load(21, tokens, 0);
+
+        const instr = core.readAt(null, 21);
+
+        expect(instr.aOperand.address).to.be.equal(7999);
+        expect(instr.bOperand.address).to.be.equal(1);
+    });
+
     it("Correctly interprets token opcodes into simulator instructions", () => {
 
         var core = buildCore(20);
@@ -270,14 +290,14 @@ describe("WarriorLoader", () => {
         expect(core.readAt(null, 5).aOperand.address).to.be.equal(10);
         expect(core.readAt(null, 6).aOperand.address).to.be.equal(12);
         expect(core.readAt(null, 7).aOperand.address).to.be.equal(14);
-        expect(core.readAt(null, 8).aOperand.address).to.be.equal(-1);
-        expect(core.readAt(null, 9).aOperand.address).to.be.equal(-3);
-        expect(core.readAt(null, 10).aOperand.address).to.be.equal(-5);
-        expect(core.readAt(null, 11).aOperand.address).to.be.equal(-7);
-        expect(core.readAt(null, 12).aOperand.address).to.be.equal(-9);
-        expect(core.readAt(null, 13).aOperand.address).to.be.equal(-11);
-        expect(core.readAt(null, 14).aOperand.address).to.be.equal(-13);
-        expect(core.readAt(null, 15).aOperand.address).to.be.equal(-15);
+        expect(core.readAt(null, 8).aOperand.address).to.be.equal(7999);
+        expect(core.readAt(null, 9).aOperand.address).to.be.equal(7997);
+        expect(core.readAt(null, 10).aOperand.address).to.be.equal(7995);
+        expect(core.readAt(null, 11).aOperand.address).to.be.equal(7993);
+        expect(core.readAt(null, 12).aOperand.address).to.be.equal(7991);
+        expect(core.readAt(null, 13).aOperand.address).to.be.equal(7989);
+        expect(core.readAt(null, 14).aOperand.address).to.be.equal(7987);
+        expect(core.readAt(null, 15).aOperand.address).to.be.equal(7985);
         expect(core.readAt(null, 16).aOperand.address).to.be.equal(0);
     });
 
@@ -322,14 +342,14 @@ describe("WarriorLoader", () => {
         expect(core.readAt(null, 5).bOperand.address).to.be.equal(11);
         expect(core.readAt(null, 6).bOperand.address).to.be.equal(13);
         expect(core.readAt(null, 7).bOperand.address).to.be.equal(15);
-        expect(core.readAt(null, 8).bOperand.address).to.be.equal(-2);
-        expect(core.readAt(null, 9).bOperand.address).to.be.equal(-4);
-        expect(core.readAt(null, 10).bOperand.address).to.be.equal(-6);
-        expect(core.readAt(null, 11).bOperand.address).to.be.equal(-8);
-        expect(core.readAt(null, 12).bOperand.address).to.be.equal(-10);
-        expect(core.readAt(null, 13).bOperand.address).to.be.equal(-12);
-        expect(core.readAt(null, 14).bOperand.address).to.be.equal(-14);
-        expect(core.readAt(null, 15).bOperand.address).to.be.equal(-16);
+        expect(core.readAt(null, 8).bOperand.address).to.be.equal(7998);
+        expect(core.readAt(null, 9).bOperand.address).to.be.equal(7996);
+        expect(core.readAt(null, 10).bOperand.address).to.be.equal(7994);
+        expect(core.readAt(null, 11).bOperand.address).to.be.equal(7992);
+        expect(core.readAt(null, 12).bOperand.address).to.be.equal(7990);
+        expect(core.readAt(null, 13).bOperand.address).to.be.equal(7988);
+        expect(core.readAt(null, 14).bOperand.address).to.be.equal(7986);
+        expect(core.readAt(null, 15).bOperand.address).to.be.equal(7984);
         expect(core.readAt(null, 16).bOperand.address).to.be.equal(0);
     });
 
@@ -378,7 +398,7 @@ describe("WarriorLoader", () => {
         var core = buildCore(0);
 
         var loader = new WarriorLoader(core, this.publisher);
-        
+
         var actual = null;
         (<sinon.stub>core.setAt).callsFake((task, address, instruction) => {
 
@@ -412,7 +432,7 @@ describe("WarriorLoader", () => {
 
         const expectedData = {
             foo: "foo",
-            array: [ 1, 2, 3 ]
+            array: [1, 2, 3]
         };
         const expectedId = 5;
         const core = buildCore(0);
@@ -448,7 +468,7 @@ describe("WarriorLoader", () => {
         tokens.data = expected;
 
         const loader = new WarriorLoader(core, this.publisher);
-        
+
         const actual = loader.load(0, tokens, 0);
 
         expect(actual.data).to.be.deep.equal(expected);


### PR DESCRIPTION
Fix for #162 

Apply mod wrapping when warriors are loaded into to core and also when applying pre-decrement and post-increment addressing modes.  All addresses in core are always unsigned.