### PR TITLE
Match result

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -50,6 +50,7 @@ import { PerKeyStrategy } from "./simulator/PerKeyStrategy";
 import { MatchRunner } from "./matches/MatchRunner";
 
 import * as clone from "clone";
+import { MatchResultMapper } from "./matches/MatchResultMapper";
 
 class Api {
 
@@ -119,6 +120,7 @@ class Api {
 
         this.matchRunner = new MatchRunner(
             this.simulator,
+            new MatchResultMapper(),
             this.publisher);
     }
 

--- a/matches/MatchResultMapper.ts
+++ b/matches/MatchResultMapper.ts
@@ -1,0 +1,41 @@
+import { IMatchResultMapper } from "./interface/IMatchResultMapper";
+import { IMatchResult } from "./interface/IMatchResult";
+import { IMatch } from "./interface/IMatch";
+import { SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION } from "constants";
+import { IMatchWarriorResult } from "./interface/IMatchWarriorResult";
+
+export class MatchResultMapper implements IMatchResultMapper {
+
+    private getWarriorResult(warrior, match): IMatchWarriorResult {
+
+        const rounds = match.rules.rounds;
+
+        const won = warrior.wins;
+        const lost: number = match.warriors
+            .filter(w => warrior.warriorMatchId != w.warriorMatchId)
+            .map(w => w.wins)
+            .reduce((t, w) => t + w, 0);
+        const drawn = rounds - won - lost;
+
+        const winpoints = won / rounds * 100 * 3;
+        const drawpoints = drawn / rounds * 100 * 1;
+        const losepoints = lost / rounds * 100 * 3;
+
+        return {
+            source: warrior.source,
+            won,
+            drawn,
+            lost,
+            given: losepoints + drawpoints,
+            taken: winpoints + drawpoints
+        };
+    }
+
+    public map(match: IMatch): IMatchResult {
+
+        return {
+            rounds: match.rules.rounds,
+            warriors: match.warriors.map(w => this.getWarriorResult(w, match))
+        };
+    }
+}

--- a/matches/MatchRunner.ts
+++ b/matches/MatchRunner.ts
@@ -3,16 +3,22 @@ import { IMatch } from "./interface/IMatch";
 import { ISimulator } from "../simulator/interface/ISimulator";
 import { IPublisher } from "../simulator/interface/IPublisher";
 import { MessageType } from "../simulator/interface/IMessage";
+import { IMatchResultMapper } from "./interface/IMatchResultMapper";
 import * as clone from "clone";
 
 export class MatchRunner implements IMatchRunner {
 
     private simulator: ISimulator;
     private publisher: IPublisher;
+    private matchResultMapper: IMatchResultMapper;
 
-    constructor(simulator: ISimulator, publisher: IPublisher) {
+    constructor(
+        simulator: ISimulator,
+        matchResultMapper: IMatchResultMapper,
+        publisher: IPublisher) {
 
         this.simulator = simulator;
+        this.matchResultMapper = matchResultMapper;
         this.publisher = publisher;
     }
 

--- a/matches/MatchRunner.ts
+++ b/matches/MatchRunner.ts
@@ -4,6 +4,7 @@ import { ISimulator } from "../simulator/interface/ISimulator";
 import { IPublisher } from "../simulator/interface/IPublisher";
 import { MessageType } from "../simulator/interface/IMessage";
 import { IMatchResultMapper } from "./interface/IMatchResultMapper";
+import { IMatchResult } from "./interface/IMatchResult";
 import * as clone from "clone";
 
 export class MatchRunner implements IMatchRunner {
@@ -22,18 +23,16 @@ export class MatchRunner implements IMatchRunner {
         this.publisher = publisher;
     }
 
-    private publishEnd(warriors) {
+    private publishEnd(result) {
 
         this.publisher.queue({
             type: MessageType.MatchEnd,
-            payload: {
-                warriors: clone(warriors)
-            }
+            payload: result
         });
         this.publisher.publish();
     }
 
-    run(match: IMatch): IMatch {
+    run(match: IMatch): IMatchResult {
 
         for (let i = 0; i < match.warriors.length; i++) {
             const warrior = match.warriors[i];
@@ -60,8 +59,10 @@ export class MatchRunner implements IMatchRunner {
             }
         }
 
-        this.publishEnd(match.warriors);
+        const result = this.matchResultMapper.map(match);
 
-        return clone(match);
+        this.publishEnd(result);
+
+        return result;
     }
 }

--- a/matches/interface/IMatchResult.ts
+++ b/matches/interface/IMatchResult.ts
@@ -1,0 +1,7 @@
+import { IMatchWarriorResult } from "./IMatchWarriorResult";
+
+export interface IMatchResult {
+
+    rounds: number;
+    warriors: IMatchWarriorResult[];
+}

--- a/matches/interface/IMatchResultMapper.ts
+++ b/matches/interface/IMatchResultMapper.ts
@@ -1,0 +1,7 @@
+import { IMatchResult } from "./IMatchResult";
+import { IMatch } from "./IMatch";
+
+export interface IMatchResultMapper {
+
+    map(match: IMatch): IMatchResult
+}

--- a/matches/interface/IMatchRunner.ts
+++ b/matches/interface/IMatchRunner.ts
@@ -1,6 +1,7 @@
 import { IMatch } from "./IMatch";
+import { IMatchResult } from "./IMatchResult";
 
 export interface IMatchRunner {
 
-    run(match: IMatch): IMatch;
+    run(match: IMatch): IMatchResult;
 }

--- a/matches/interface/IMatchWarriorResult.ts
+++ b/matches/interface/IMatchWarriorResult.ts
@@ -1,0 +1,11 @@
+import { IParseResult } from "../../parser/interface/IParseResult";
+
+export interface IMatchWarriorResult {
+
+    source: IParseResult;
+    won: number;
+    drawn: number;
+    lost: number;
+    given: number;
+    taken: number;
+}

--- a/matches/tests/MatchResultMapperTests.ts
+++ b/matches/tests/MatchResultMapperTests.ts
@@ -1,0 +1,105 @@
+import * as chai from "chai";
+var expect = chai.expect;
+
+import { IMatchResultMapper } from "../interface/IMatchResultMapper";
+import { MatchResultMapper } from "../MatchResultMapper";
+import TestHelper from "../../simulator/tests/TestHelper";
+
+describe("MatchResultMapper", () => {
+
+    let matchResultMapper: IMatchResultMapper;
+
+    beforeEach(() => {
+
+        matchResultMapper = new MatchResultMapper();
+    });
+
+    const buildMatch = (rounds) => {
+
+        return {
+            rules: {
+                rounds: rounds,
+                options: {}
+            },
+            warriors: [
+                { wins: 0, warriorMatchId: 0, source: TestHelper.buildParseResult([]) },
+                { wins: 0, warriorMatchId: 1, source: TestHelper.buildParseResult([]) }
+            ]
+        };
+    };
+
+    it("returns a match result with the correct number of rounds", () => {
+
+        const expected = 7;
+
+        const actual = matchResultMapper.map(buildMatch(expected));
+
+        expect(actual.rounds).to.be.equal(expected);
+    });
+
+    it("associates each result with the corresponding warrior source", () => {
+
+        const match = buildMatch(1);
+
+        const expected = [
+            match.warriors[0].source,
+            match.warriors[1].source
+        ];
+
+        const actual = matchResultMapper.map(match);
+
+        expect(actual.warriors.length).to.be.equal(2);
+        
+        expected.forEach((e, i) => expect(match.warriors[i].source).to.be.equal(e));
+    });
+
+    it("correctly calculates won, drawn and lost", () => {
+
+        const match = buildMatch(10);
+
+        match.warriors[0].wins = 3;
+        match.warriors[1].wins = 2;
+
+        const actual = matchResultMapper.map(match);
+
+        expect(actual.warriors.length).to.be.equal(2);
+
+        const a = actual.warriors[0];
+        expect(a.won).to.be.equal(3);
+        expect(a.drawn).to.be.equal(5);
+        expect(a.lost).to.be.equal(2);
+
+        const b = actual.warriors[1];
+        expect(b.won).to.be.equal(2);
+        expect(b.drawn).to.be.equal(5);
+        expect(b.lost).to.be.equal(3);
+    });
+
+    it("correctly calculates points taken and given", () => {
+
+        const match = buildMatch(10);
+
+        match.warriors[0].wins = 3;
+        match.warriors[1].wins = 2;
+
+        const actual = matchResultMapper.map(match);
+
+        expect(actual.warriors.length).to.be.equal(2);
+
+        const a = actual.warriors[0];
+        expect(a.taken).to.be.equal(140);
+        expect(a.given).to.be.equal(110);
+
+        const b = actual.warriors[1];
+        expect(b.taken).to.be.equal(110);
+        expect(b.given).to.be.equal(140);
+    });
+
+    it("handles a match with a single warrior", () => {
+
+        const match = buildMatch(1);
+        match.warriors = match.warriors.splice(1, 1);
+
+        const actual = matchResultMapper.map(match);
+    });
+});

--- a/matches/tests/MatchRunnerTests.ts
+++ b/matches/tests/MatchRunnerTests.ts
@@ -11,16 +11,22 @@ import { MatchRunner } from "../MatchRunner";
 import { ISimulator } from "../../simulator/interface/ISimulator";
 import { IPublisher } from "../../simulator/interface/IPublisher";
 import { MessageType } from "../../simulator/interface/IMessage";
+import { IMatchResultMapper } from "../interface/IMatchResultMapper";
 
 describe("MatchRunner", () => {
 
     let matchRunner: IMatchRunner;
     let simulator: ISimulator;
     let publisher: IPublisher;
+    let matchResultMapper: IMatchResultMapper;
 
     beforeEach(() => {
 
         publisher = TestHelper.buildPublisher();
+
+        matchResultMapper = {
+            map: sinon.stub()
+        };
 
         simulator = {
             initialise: sinon.stub(),
@@ -30,7 +36,7 @@ describe("MatchRunner", () => {
         };
         (<sinon.stub>simulator.run).returns({});
 
-        matchRunner = new MatchRunner(simulator, publisher);
+        matchRunner = new MatchRunner(simulator, matchResultMapper, publisher);
     });
 
     it("Assigns a unique match ID to each warrior", () => {

--- a/matches/tests/MatchRunnerTests.ts
+++ b/matches/tests/MatchRunnerTests.ts
@@ -55,8 +55,19 @@ describe("MatchRunner", () => {
             ]
         };
 
-        const actual = matchRunner.run(match);
+        let actual = null;
+        (<sinon.stub>matchResultMapper.map).callsFake(m => {
 
+            actual = m;
+            return {
+                rounds: 1,
+                warriors: []
+            };
+        });
+
+        matchRunner.run(match);
+
+        expect(actual).not.be.null;
         expect(actual.warriors.length).to.be.equal(expected.length);
         for (let i = 0; i < expected.length; i++) {
             expect(actual.warriors[i].warriorMatchId).to.be.equal(expected[i]);
@@ -111,8 +122,19 @@ describe("MatchRunner", () => {
 
         roundResults.forEach((r, i) => (<sinon.stub>simulator.run).onCall(i).returns(r));
 
-        const actual = matchRunner.run(match);
+        let actual = null;
+        (<sinon.stub>matchResultMapper.map).callsFake(m => {
 
+            actual = m;
+            return {
+                rounds: 1,
+                warriors: []
+            };
+        });
+
+        matchRunner.run(match);
+
+        expect(actual).not.to.be.null;
         expect(actual.warriors.length).to.be.equal(2);
         expect(actual.warriors[0].wins).to.be.equal(2);
         expect(actual.warriors[1].wins).to.be.equal(1);
@@ -169,13 +191,17 @@ describe("MatchRunner", () => {
             winnerData: { warriorMatchId: 0 }
         });
 
+        const expected = {
+            rounds: 1,
+            warriors: []
+        };
+        (<sinon.stub>matchResultMapper.map).returns(expected);
+
         const actual = matchRunner.run(match);
 
         expect(publisher.queue).to.have.been.calledWith({
             type: MessageType.MatchEnd,
-            payload: {
-                warriors: actual.warriors
-            }
+            payload: expected
         });
         expect(publisher.publish).to.have.been.called;
     });


### PR DESCRIPTION
`MatchRunner` now returns and publishes `IMatchResult` at the end of the match.

`IMatchResult` contains won/drawn/lost and points given/taken for each warrior.

Addresses #186 