### PR TITLE
Round progress

### DIFF
--- a/simulator/Defaults.ts
+++ b/simulator/Defaults.ts
@@ -5,7 +5,7 @@ import { ModeType } from "./interface/IOperand";
 class Defaults implements IOptions {
 
     public coresize: number = 8000;
-    public cyclesBeforeTie: number = 80000;
+    public maximumCycles: number = 80000;
     public initialInstruction: IInstruction = {
         address: 0,
         opcode: OpcodeType.DAT,

--- a/simulator/EndCondition.ts
+++ b/simulator/EndCondition.ts
@@ -36,14 +36,14 @@ export class EndCondition implements IEndCondition {
         });
     }
 
-    private publishProgress(cycle: number, cyclesBeforeDraw: number) {
+    private publishProgress(cycle: number, maximumCycles: number) {
 
         this.publisher.queue({
             type: MessageType.RunProgress,
             payload: {
-                runProgress: cycle / cyclesBeforeDraw * 100.0,
+                runProgress: cycle / maximumCycles * 100.0,
                 cycle,
-                cyclesBeforeDraw
+                maximumCycles
             }
         });
     }
@@ -60,8 +60,7 @@ export class EndCondition implements IEndCondition {
         }
 
         const liveWarriors = state.warriors.filter((warrior: IWarrior) => warrior.tasks.length > 0);
-        let result = liveWarriors.length === 1;
-
+        
         if (state.warriors.length === 1) {
             if (liveWarriors.length === 0) {
                 this.publishRoundEnd('NONE');

--- a/simulator/EndCondition.ts
+++ b/simulator/EndCondition.ts
@@ -36,12 +36,14 @@ export class EndCondition implements IEndCondition {
         });
     }
 
-    private publishProgress(progress: number) {
+    private publishProgress(cycle: number, cyclesBeforeDraw: number) {
 
         this.publisher.queue({
             type: MessageType.RunProgress,
             payload: {
-                runProgress: progress
+                runProgress: cycle / cyclesBeforeDraw * 100.0,
+                cycle,
+                cyclesBeforeDraw
             }
         });
     }
@@ -54,7 +56,7 @@ export class EndCondition implements IEndCondition {
         }
 
         if ((state.cycle % (state.options.cyclesBeforeTie / 100)) === 0) {
-            this.publishProgress(state.cycle / (state.options.cyclesBeforeTie / 100));
+            this.publishProgress(state.cycle, state.options.cyclesBeforeTie);
         }
 
         const liveWarriors = state.warriors.filter((warrior: IWarrior) => warrior.tasks.length > 0);

--- a/simulator/EndCondition.ts
+++ b/simulator/EndCondition.ts
@@ -15,13 +15,6 @@ export class EndCondition implements IEndCondition {
 
     private publishRoundEnd(outcome: string, winner: IWarrior = null) {
 
-        this.publisher.queue({
-            type: MessageType.RunProgress,
-            payload: {
-                runProgress: 100
-            }
-        });
-
         const payload =  {
             winnerId: winner && winner.id,
             outcome

--- a/simulator/EndCondition.ts
+++ b/simulator/EndCondition.ts
@@ -50,13 +50,13 @@ export class EndCondition implements IEndCondition {
 
     public check(state: IState): boolean {
 
-        if (state.cycle >= state.options.cyclesBeforeTie) {
+        if (state.cycle >= state.options.maximumCycles) {
             this.publishRoundEnd('DRAW');
             return true;
         }
 
-        if ((state.cycle % (state.options.cyclesBeforeTie / 100)) === 0) {
-            this.publishProgress(state.cycle, state.options.cyclesBeforeTie);
+        if ((state.cycle % (state.options.maximumCycles / 100)) === 0) {
+            this.publishProgress(state.cycle, state.options.maximumCycles);
         }
 
         const liveWarriors = state.warriors.filter((warrior: IWarrior) => warrior.tasks.length > 0);

--- a/simulator/OptionValidator.ts
+++ b/simulator/OptionValidator.ts
@@ -9,7 +9,7 @@ export class OptionValidator implements IOptionValidator {
     public static MinSeparationNegativeMessage = "MinSeparation must be a positive integer";
     public static InstructionLimitNegativeMessage = "InstructionLimit must be a positive integer";
     public static CoreTooSmallForWarriorsMessage = "The coresize is too small for all warriors to be placed. Coresize must be greater than minSeparation plus instructionLimit multiplied by number of warriors";
-    public static CyclesBeforeTieNegativeMessage = "cyclesBeforeTie must be an integer greater than zero";
+    public static MaximumCyclesNegativeMessage = "maximumCycles must be an integer greater than zero";
     public static MaxTasksNegativeMessage = "maxTasks must be an integer greater than zero";
     public static NoInitialInstructionMessage = "No initial instruction specified";
     public static InitialInstructionOpcodeMessage = "Initial instruction must have a valid opcode";
@@ -39,8 +39,8 @@ export class OptionValidator implements IOptionValidator {
             throw Error(OptionValidator.CoreTooSmallForWarriorsMessage);
         }
 
-        if (state.cyclesBeforeTie < 1) {
-            throw Error(OptionValidator.CyclesBeforeTieNegativeMessage);
+        if (state.maximumCycles < 1) {
+            throw Error(OptionValidator.MaximumCyclesNegativeMessage);
         }
 
         if (state.maxTasks < 1) {

--- a/simulator/Simulator.ts
+++ b/simulator/Simulator.ts
@@ -101,7 +101,7 @@ export class Simulator implements ISimulator {
 
     public run(): void {
 
-        const remainingSteps = this.state.options.cyclesBeforeTie - this.state.cycle;
+        const remainingSteps = this.state.options.maximumCycles - this.state.cycle;
 
         this.step(remainingSteps);
     }

--- a/simulator/interface/IOptions.ts
+++ b/simulator/interface/IOptions.ts
@@ -3,7 +3,7 @@
 export interface IOptions {
 
     coresize?: number;
-    cyclesBeforeTie?: number;
+    maximumCycles?: number;
     initialInstruction?: IInstruction;
     instructionLimit?: number;
     maxTasks?: number;

--- a/simulator/tests/EndConditionTests.ts
+++ b/simulator/tests/EndConditionTests.ts
@@ -262,7 +262,7 @@ describe("EndCondition", () => {
             payload: {
                 runProgress: 12,
                 cycle: 12 * 5,
-                cyclesBeforeDraw: 100 * 5
+                maximumCycles: 100 * 5
             }
         });
 

--- a/simulator/tests/EndConditionTests.ts
+++ b/simulator/tests/EndConditionTests.ts
@@ -2,7 +2,6 @@
 import * as sinon from "sinon";
 
 import { ITask } from "../interface/ITask";
-import { ICore, ICoreAccessEventArgs, CoreAccessType } from "../interface/ICore";
 import { IWarrior } from "../interface/IWarrior";
 import { IState } from "../interface/IState";
 import Defaults from "../Defaults";
@@ -261,7 +260,9 @@ describe("EndCondition", () => {
         expect(publisher.queue).to.have.been.calledWith({
             type: MessageType.RunProgress,
             payload: {
-                runProgress: 12
+                runProgress: 12,
+                cycle: 12 * 5,
+                cyclesBeforeDraw: 100 * 5
             }
         });
 

--- a/simulator/tests/EndConditionTests.ts
+++ b/simulator/tests/EndConditionTests.ts
@@ -147,7 +147,7 @@ describe("EndCondition", () => {
 
         endCondition.check(state);
 
-        expect(publisher.queue).to.have.been.calledWith({
+        expect(publisher.queue).not.to.have.been.calledWith({
             type: MessageType.RunProgress,
             payload: {
                 runProgress: 100
@@ -175,7 +175,7 @@ describe("EndCondition", () => {
 
         endCondition.check(state);
 
-        expect(publisher.queue).to.have.been.calledWith({
+        expect(publisher.queue).not.to.have.been.calledWith({
             type: MessageType.RunProgress,
             payload: {
                 runProgress: 100
@@ -230,7 +230,7 @@ describe("EndCondition", () => {
 
         endCondition.check(state);
 
-        expect(publisher.queue).to.have.been.calledWith({
+        expect(publisher.queue).not.to.have.been.calledWith({
             type: MessageType.RunProgress,
             payload: {
                 runProgress: 100

--- a/simulator/tests/EndConditionTests.ts
+++ b/simulator/tests/EndConditionTests.ts
@@ -73,7 +73,7 @@ describe("EndCondition", () => {
         var state = buildState();
 
         state.cycle = 123;
-        state.options.cyclesBeforeTie = 123;
+        state.options.maximumCycles = 123;
 
         var endCondition = new EndCondition(publisher);
 
@@ -87,7 +87,7 @@ describe("EndCondition", () => {
         var state = buildState();
 
         state.cycle = 124;
-        state.options.cyclesBeforeTie = 123;
+        state.options.maximumCycles = 123;
 
         var endCondition = new EndCondition(publisher);
 
@@ -141,7 +141,7 @@ describe("EndCondition", () => {
         const state = buildState();
 
         state.cycle = 123;
-        state.options.cyclesBeforeTie = 123;
+        state.options.maximumCycles = 123;
 
         const endCondition = new EndCondition(publisher);
 
@@ -251,7 +251,7 @@ describe("EndCondition", () => {
         const state = buildState();
 
         state.cycle = 12 * 5;
-        state.options.cyclesBeforeTie = 100 * 5;
+        state.options.maximumCycles = 100 * 5;
 
         const endCondition = new EndCondition(publisher);
 

--- a/simulator/tests/OptionValidatorTests.ts
+++ b/simulator/tests/OptionValidatorTests.ts
@@ -73,11 +73,11 @@ describe("OptionValidator", () => {
         validateAndExpect(options, 2, OptionValidator.CoreTooSmallForWarriorsMessage)
     });
 
-    it("Throws if cyclesBeforeTie is less than one", () => {
+    it("Throws if maximumCycles is less than one", () => {
 
-        options.cyclesBeforeTie = 0;
+        options.maximumCycles = 0;
 
-        validateAndExpect(options, 1, OptionValidator.CyclesBeforeTieNegativeMessage);
+        validateAndExpect(options, 1, OptionValidator.MaximumCyclesNegativeMessage);
     });
 
     it("Throws if maxTasks is less than one", () => {

--- a/simulator/tests/SimulatorTests.ts
+++ b/simulator/tests/SimulatorTests.ts
@@ -203,7 +203,7 @@ describe("Simulator", () => {
 
         var expected: IOptions = {
             coresize: 100,
-            cyclesBeforeTie: 100,
+            maximumCycles: 100,
             initialInstruction: {
                 address: 100,
                 aOperand: {


### PR DESCRIPTION
In addition to `runProgress` percentage, the `RUN_PROGRESS` message includes current cycle number (`cycle`) and the maximum number of cycles (`maximumCycles`).

Rename cyclesBeforeTie to `maximumCycles` throughout

Do not publish progress of 100% when round ends in a win.

Addresses #185 