### PR TITLE
Always push round progress messages to publisher

### DIFF
--- a/simulator/EndCondition.ts
+++ b/simulator/EndCondition.ts
@@ -55,10 +55,8 @@ export class EndCondition implements IEndCondition {
             return result;
         }
 
-        if ((state.cycle % (state.options.maximumCycles / 100)) === 0) {
-            this.publishProgress(state.cycle, state.options.maximumCycles);
-        }
-
+        this.publishProgress(state.cycle, state.options.maximumCycles);
+        
         const liveWarriors = state.warriors.filter((warrior: IWarrior) => warrior.tasks.length > 0);
         
         if (state.warriors.length === 1) {


### PR DESCRIPTION
Push `ROUND_PROGRESS` message to `Publisher` every cycle so that the UI can show the current cycle number correctly.

Previously, `ROUND_PROGRESS` was only published every x cycles for performance reasons.  This is no longer necessary as `Publisher` ensures only one `ROUND_PROGRESS` message is raised per simulator step regardless of how many `ROUND_PROGRESS` messages are pushed to it.