### PR TITLE
Fix 193

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corewar",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "HTML5 & javascript implementation of the classic game [corewar](https://en.wikipedia.org/wiki/Core_War)",
   "main": "./dist/index.js",
   "scripts": {

--- a/parser/integration/tests/RegressionTests.ts
+++ b/parser/integration/tests/RegressionTests.ts
@@ -3,7 +3,7 @@ import { TestHelper } from  "./TestHelper";
 import { Standard } from "./../../interface/IParseOptions";
 import { MessageType } from "../../interface/IMessage";
 
-describe("Regression Tests",() => {
+describe("Parser Regression Tests",() => {
 
     it("correctly handles an instruction with no modifier",() => {
         const actual = TestHelper.testWarriorParse("MOV", Standard.ICWS94draft);

--- a/simulator/integration/RegressionTests.ts
+++ b/simulator/integration/RegressionTests.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { Simulator } from "../Simulator";
+import { Core } from "../Core";
+import { Fetcher } from "../Fetcher";
+import { Decoder } from "../Decoder";
+import { Executive } from "../Executive";
+import { ILoader } from "../interface/ILoader";
+import { IEndCondition } from "../interface/IEndCondition";
+import { IOptionValidator } from "../interface/IOptionValidator";
+import { ICore } from "../interface/ICore";
+import { IFetcher } from "../interface/IFetcher";
+import { IExecutive } from "../interface/IExecutive";
+import { IDecoder } from "../interface/IDecoder";
+import { ISimulator } from "../interface/ISimulator";
+import { IPublisher } from "../interface/IPublisher";
+import TestHelper from "../tests/TestHelper";
+import { IWarrior } from "../interface/IWarrior";
+import { IInstruction, OpcodeType, ModifierType } from "../interface/IInstruction";
+import { ModeType } from "../interface/IOperand";
+import { ITask } from "../interface/ITask";
+
+describe("Simulator Regression Tests", () => {
+
+    let publisher: IPublisher;
+    let loader: ILoader;
+    let endCondition: IEndCondition;
+    let optionValidator: IOptionValidator;
+
+    let core: ICore;
+    let fetcher: IFetcher;
+    let executive: IExecutive;
+    let decoder: IDecoder;
+    let simulator: ISimulator;
+
+    let warrior: IWarrior;
+    let task: ITask;
+
+    beforeEach(() => {
+
+        publisher = TestHelper.getPublisher();
+        loader = TestHelper.getLoader();
+        endCondition = TestHelper.getEndCondition();
+        optionValidator = TestHelper.getOptionValidator();
+
+        core = new Core(publisher);
+        fetcher = new Fetcher();
+        executive = new Executive(publisher);
+        decoder = new Decoder(executive);
+        simulator = new Simulator(core, loader, fetcher, decoder, executive, endCondition, optionValidator, publisher);
+
+        warrior = TestHelper.buildWarrior();
+        task = TestHelper.buildTask();
+        task.warrior = warrior;
+        warrior.tasks.push(task);
+        (<sinon.stub>loader.load).returns([warrior]);
+
+        simulator.initialise({}, []);
+    });
+
+    it("correctly processes add.a with a field predecrement indirect addressing", () => {
+
+        task.instructionPointer = 1;
+
+        //DAT.F $5, $0
+        //ADD.A {0, $0
+        const instructions = [
+            TestHelper.buildInstruction(0, OpcodeType.DAT, ModifierType.F, ModeType.Direct, 5, ModeType.Direct, 0),
+            TestHelper.buildInstruction(1, OpcodeType.ADD, ModifierType.A, ModeType.APreDecrement, 0, ModeType.Immediate, 0)
+        ];
+
+        instructions.forEach((instruction, index) => {
+            core.setAt(warrior.tasks[0], index, instruction);
+        });
+
+        simulator.step();
+
+        const actual = core.getAt(1);
+
+        expect(actual.aOperand.address).to.be.equal(5);        
+    });
+});

--- a/simulator/tests/DecoderTests.ts
+++ b/simulator/tests/DecoderTests.ts
@@ -51,7 +51,7 @@ describe("Decoder", () => {
         { core: ["NOP.I $1, $2", "ADD.AB $-1, $1", "DAT.F $5, $6"], ip: 1, e: ["NOP.I $1, $2", "DAT.F $5, $6"] },
         { core: ["NOP.I $2, $1", "ADD.AB *-1, *1", "DAT.F $-1, $1"], ip: 1, e: ["DAT.F $-1, $1", "ADD.AB *-1, *1"] },
         { core: ["NOP.I $1, $2", "ADD.AB @-1, @1", "DAT.F $5, $-1"], ip: 1, e: ["DAT.F $5, $-1", "ADD.AB @-1, @1"] },
-        { core: ["NOP.I $1, $2", "ADD.AB {-1, {1", "DAT.F $0, $6"], ip: 1, e: ["NOP.I $0, $2", "ADD.AB {-1, {1"] },
+        { core: ["NOP.I $1, $2", "ADD.AB {0, {1", "DAT.F $0, $6"], ip: 1, e: ["NOP.I $1, $2", "ADD.AB {0, {1"] },
         { core: ["NOP.I $2, $1", "ADD.AB <-1, <1", "DAT.F $5, $0"], ip: 1, e: ["NOP.I $2, $0", "ADD.AB <-1, <1"] },
         { core: ["NOP.I $1, $2", "ADD.AB }-1, }1", "DAT.F $0, $6"], ip: 1, e: ["ADD.AB }-1, }1", "DAT.F $0, $6"] },
         { core: ["NOP.I $2, $0", "ADD.AB >-1, >1", "DAT.F $5, $-1"], ip: 1, e: ["NOP.I $2, $0", "ADD.AB >-1, >1"] }

--- a/simulator/tests/TestHelper.ts
+++ b/simulator/tests/TestHelper.ts
@@ -11,6 +11,9 @@ import { IInstruction } from "../interface/IInstruction";
 import { ICore } from "../interface/ICore";
 import { IOptions } from "../interface/IOptions";
 import { IPublisher } from "../interface/IPublisher";
+import { ILoader } from "../interface/ILoader";
+import { IEndCondition } from "../interface/IEndCondition";
+import { IOptionValidator } from "../interface/IOptionValidator";
 
 "use strict";
 
@@ -294,5 +297,37 @@ export default class TestHelper {
                     return prop;
             }
         }
+    }
+
+    public static getPublisher(): IPublisher {
+
+        return {
+            queue: sinon.stub(),
+            publish: sinon.stub(),
+            republish: sinon.stub(),
+            clear: sinon.stub(),
+            setPublishProvider: sinon.stub()
+        };
+    }
+
+    public static getLoader(): ILoader {
+
+        return {
+            load: sinon.stub()
+        };
+    }
+
+    public static getEndCondition(): IEndCondition {
+
+        return {
+            check: sinon.stub()
+        };
+    }
+
+    public static getOptionValidator(): IOptionValidator {
+
+        return {
+            validate: sinon.stub()
+        };
     }
 }


### PR DESCRIPTION
Resolve #193 
When decoding A and B operands, store any changes to core in array.
Once both operands are decoded, loop through cached changes and write to core before executing the decoded instruction.
This should allow corewar.io to emulate PMARS:
```
DAT.F $5, $0
ADD.A {0, #0 
```
After executing the `ADD`, the core should look like this:
```
DAT.F $5, $0
ADD.A {5, #0
```
